### PR TITLE
Initscript cleanup

### DIFF
--- a/conf/aeolus-conductor
+++ b/conf/aeolus-conductor
@@ -19,6 +19,7 @@ CONDUCTOR_GROUP="${CONDUCTOR_GROUP:-aeolus}"
 THIN_PROG="${THIN_PROG:-thin}"
 THIN_PID="${THIN_PID:-/var/run/aeolus-conductor/thin.pid}"
 THIN_LOG="${THIN_LOG:-/var/log/aeolus-conductor/thin.log}"
+THIN_LOCKFILE="${THIN_LOCKFILE:-/var/lock/subsys/aeolus-conductor}"
 PREFIX="${PREFIX:-/conductor}"
 ADDR="${ADDR:-127.0.0.1}"
 
@@ -30,11 +31,11 @@ STARTTIMEOUT=60
 . /etc/init.d/functions
 
 start() {
-    echo -n "Starting aeolus-conductor: "
+    echo -n "Starting ${THIN_PROG}: "
     if [ -f "$THIN_PID" ] && checkpid `cat $THIN_PID` ; then
         echo_failure
         echo
-        echo "Thin is already running"
+        echo "${THIN_PROG} is already running"
         exit 1
     fi
 
@@ -50,6 +51,7 @@ start() {
             /usr/bin/curl --silent http://$ADDR:3000$PREFIX >& /dev/null
             RETVAL=$?
             if [ $RETVAL -eq 0 ] ; then
+                touch ${THIN_LOCKFILE}
                 echo_success
                 echo
                 exit 0
@@ -65,8 +67,11 @@ start() {
 }
 
 stop() {
-    echo -n "Shutting down aeolus-conductor: "
-    killproc -p $THIN_PID thin
+    echo -n "Shutting down ${THIN_PROG}: "
+    killproc -p $THIN_PID ${THIN_PROG}
+    RETVAL=$?
+    echo
+    [ $RETVAL = 0 ] && rm -f ${THIN_LOCKFILE} ${THIN_PID}
 }
 
 case "$1" in
@@ -86,7 +91,7 @@ case "$1" in
         restart
         ;;
     status)
-        status -p $THIN_PID
+        status -p ${THIN_PID} ${THIN_PROG}
         RETVAL=$?
         ;;
     *)

--- a/conf/aeolus-conductor
+++ b/conf/aeolus-conductor
@@ -32,36 +32,36 @@ STARTTIMEOUT=60
 start() {
     echo -n "Starting aeolus-conductor: "
     if [ -f "$THIN_PID" ] && checkpid `cat $THIN_PID` ; then
-      echo_failure
-      echo
-      echo "Thin is already running"
-      exit 1
+        echo_failure
+        echo
+        echo "Thin is already running"
+        exit 1
     fi
 
     $THIN_PROG start -c "$CONDUCTOR_DIR" -l "$THIN_LOG" -P "$THIN_PID" \
-	-a $ADDR -e $RAILS_ENV --user $CONDUCTOR_USER -g $CONDUCTOR_GROUP -d --prefix=$PREFIX \
-	--rackup "$CONDUCTOR_DIR/config.ru"
+    -a $ADDR -e $RAILS_ENV --user $CONDUCTOR_USER -g $CONDUCTOR_GROUP -d --prefix=$PREFIX \
+    --rackup "$CONDUCTOR_DIR/config.ru"
     RETVAL=$?
     if [ $RETVAL -eq 0 ] ; then
-      # wait until we can contact the server
-      # this bit is based on what the mysql init script does
-      TIMEOUT="$STARTTIMEOUT"
-	     while [ $TIMEOUT -gt 0 ]; do
-        /usr/bin/curl --silent http://$ADDR:3000$PREFIX >& /dev/null
-        RETVAL=$?
-        if [ $RETVAL -eq 0 ] ; then
-	         echo_success
-	         echo
-          exit 0
-        fi
-        sleep 1
-	       let TIMEOUT=${TIMEOUT}-1
-      done
+        # wait until we can contact the server
+        # this bit is based on what the mysql init script does
+        TIMEOUT="$STARTTIMEOUT"
+        while [ $TIMEOUT -gt 0 ]; do
+            /usr/bin/curl --silent http://$ADDR:3000$PREFIX >& /dev/null
+            RETVAL=$?
+            if [ $RETVAL -eq 0 ] ; then
+                echo_success
+                echo
+                exit 0
+            fi
+            sleep 1
+            let TIMEOUT=${TIMEOUT}-1
+        done
     fi
 
-   echo_failure
-   echo
-   exit 1
+    echo_failure
+    echo
+    exit 1
 }
 
 stop() {
@@ -71,28 +71,28 @@ stop() {
 
 case "$1" in
     start)
-	start
-	;;
+        start
+        ;;
     stop)
-	stop
-	;;
+        stop
+        ;;
     restart)
-	stop
-	start
-	;;
+        stop
+        start
+        ;;
     reload)
         ;;
     force-reload)
         restart
         ;;
     status)
-	status -p $THIN_PID
-	RETVAL=$?
-	;;
+        status -p $THIN_PID
+        RETVAL=$?
+        ;;
     *)
-      echo "Usage: aeolus-conductor {start|stop|restart|reload|force-reload|status}"
-      exit 1
-  ;;
+        echo "Usage: aeolus-conductor {start|stop|restart|reload|force-reload|status}"
+        exit 1
+        ;;
 esac
 
 exit $RETVAL


### PR DESCRIPTION
Greetings,

Just a small set of fixes to the aeolus-conductor initscript to improve operation during system reboots, and improve status reporting when conductor (thin) has died.

I previously sent this to aeolus-devel@ in October, please disregard that patchset.  This pull request applies cleanly to origin.

Thanks,
James
