### PR TITLE
Display a better error if Image Factory is unreachable.

### DIFF
--- a/src/app/controllers/images_controller.rb
+++ b/src/app/controllers/images_controller.rb
@@ -203,6 +203,8 @@ class ImagesController < ApplicationController
         flash[:error] = t('images.not_on_provider')
       elsif e.is_a?(Aeolus::Conductor::Base::BlankImageId)
         flash[:error] = t('images.import.blank_id')
+      elsif e.is_a?(Errno::ECONNRESET) or e.is_a?(Errno::ECONNREFUSED)
+        flash[:error] = t('images.import.provider_unreachable')
       else
         flash[:error] = t("images.import.image_not_imported")
       end

--- a/src/config/locales/en.yml
+++ b/src/config/locales/en.yml
@@ -889,6 +889,7 @@ en:
       image_imported: The image was imported successfully.
       image_not_imported: The image could not be imported. Check the Image Factory log for further details.
       blank_id: Image ID cannot be blank.
+      provider_unreachable: "Conductor could not connect to Image Factory. Please verify that Factory is running and that its configuration matches Conductor's."
     index:
       images: Images
       name: Name


### PR DESCRIPTION
Previously, we would display an error suggesting that there was a
problem and you should check the Factory log. This was misleading
if Factory couldn't be reached, since there would be nothing
in the log.

This still isn't perfect; if Factory is entirely down, it seems
that aeolus-image-rubygem reports a bogus error. But this change
keeps Conductor from introducing any lies of its own about the cause
of the error.
