### PR TITLE
Adds an additional check in instance_errors to avoid obscure bug

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -172,7 +172,7 @@ class ApplicationController < ActionController::Base
     arr = Array.new
     instance_variables.each do |ivar|
       val = instance_variable_get(ivar)
-      if val && val.respond_to?(:errors) && val.errors.size > 0
+      if val && val.respond_to?(:errors) && val.errors.respond_to(:size) && val.errors.size > 0
         hash[:object] = ivar[1, ivar.size]
         hash[:errors] ||= []
         val.errors.each {|key,msg|


### PR DESCRIPTION
In certain cases, we somehow manage to end up with an instance variable
that responds to .errors, but doesn't return an array as expected, so
calling .errors.size on it raises an exception. This patch ensures that
the errors respond to a .size method before we call it, since raising an
exception from within code to handle exceptions is not a good thing.
This patch does not address the root cause of this problem.
