### PR TITLE
Fix MetadataObject.lookup to handle lazy-loaded classes (BZ#847373)

### DIFF
--- a/src/app/models/metadata_object.rb
+++ b/src/app/models/metadata_object.rb
@@ -43,7 +43,7 @@ class MetadataObject < ActiveRecord::Base
     if metadata_obj.nil?
       nil
     elsif metadata_obj.object_type and !metadata_obj.object_type.empty?
-      klass = ActiveRecord::Base.send(:subclasses).find{|c| c.name == metadata_obj.object_type }
+      klass = const_get(metadata_obj.object_type)
       klass.find(metadata_obj.value)
     else
       metadata_obj.value


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=847373

Under the circumstances in the above bug (running rake
dc:create_user), the Pool class (and others) have not been loaded yet
when running MetadataObject.lookup.  Because of this, Pool is not
listed in ActiveRecord::Base.subclasses, and 'klass' ends up being
nil.  When using const_get instead to obtain a handle to the desired
object class, the const_missing code paths run and Pool gets lazy
loaded.
