### PR TITLE
Adds missing route to show ProviderAccount

### DIFF
--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -158,7 +158,7 @@ Conductor::Application.routes.draw do
     end
   end
 
-  resources :provider_accounts, :only => :index
+  resources :provider_accounts, :only => [ :index, :show ]
 
   resources :provider_types, :only => :index
 


### PR DESCRIPTION
This commit add missing route to /provider_accounts/:id

That route is used for creating links on Account page (/account - Users#show) in permission table.

See http://i.imgur.com/OUK59.png
