### PR TITLE
Basic support for Kerberos SSO authentication

### DIFF
--- a/src/app/models/user.rb
+++ b/src/app/models/user.rb
@@ -127,6 +127,14 @@ class User < ActiveRecord::Base
     return u
   end
 
+  def self.authenticate_using_krb(username, ipaddress)
+    u = User.find_by_login(username) || create_krb_user!(username)
+    u.login_count += 1
+    update_login_attributes(u, ipaddress)
+    u.save!
+    u
+  end
+
   def self.update_login_attributes(u, ipaddress)
     u.login_count += 1
     u.last_login_ip = ipaddress
@@ -180,6 +188,10 @@ class User < ActiveRecord::Base
   end
 
   def self.create_ldap_user!(login)
+    User.create!(:login => login, :quota => Quota.new, :ignore_password => true)
+  end
+
+  def self.create_krb_user!(login)
     User.create!(:login => login, :quota => Quota.new, :ignore_password => true)
   end
 

--- a/src/config/initializers/warden.rb
+++ b/src/config/initializers/warden.rb
@@ -84,9 +84,10 @@ end
 
 Warden::Strategies.add(:kerberos) do
   def authenticate!
-    Rails.logger.debug("Warden is authenticating #{request.env[ 'HTTP_X_FORWARDED_USER']} against kerberos")
+    login = request.env[ 'HTTP_X_FORWARDED_USER' ]
+    Rails.logger.debug("Warden is authenticating #{login} against kerberos")
     ipaddress = request.env[ 'HTTP_X_FORWARDED_FOR' ] ? request.env[ 'HTTP_X_FORWARDED_FOR' ] : request.remote_ip
-    u = User.authenticate_using_krb(request.env[ 'HTTP_X_FORWARDED_USER'], ipaddress)
+    u = User.authenticate_using_krb(login, ipaddress)
     u ? success!(u) : fail!("Username or password is not correct - could not log in")
   end
 end

--- a/src/config/initializers/warden.rb
+++ b/src/config/initializers/warden.rb
@@ -81,6 +81,16 @@ Warden::Strategies.add(:ldap) do
     u ? success!(u) : fail!("Username or password is not correct - could not log in")
   end
 end
+
+Warden::Strategies.add(:kerberos) do
+  def authenticate!
+    Rails.logger.debug("Warden is authenticating #{request.env[ 'HTTP_X_FORWARDED_USER']} against kerberos")
+    ipaddress = request.env[ 'HTTP_X_FORWARDED_FOR' ] ? request.env[ 'HTTP_X_FORWARDED_FOR' ] : request.remote_ip
+    u = User.authenticate_using_krb(request.env[ 'HTTP_X_FORWARDED_USER'], ipaddress)
+    u ? success!(u) : fail!("Username or password is not correct - could not log in")
+  end
+end
+
 Warden::Manager.after_authentication do |user,auth,opts|
   current_session_id = auth.request.session_options[:id]
   session = auth.env['rack.session']

--- a/src/spec/models/user_spec.rb
+++ b/src/spec/models/user_spec.rb
@@ -111,6 +111,13 @@ describe User do
     u.id.should == user.id
   end
 
+  it "should authenticate a user with valid kerberos ticket" do
+    User.authenticate_using_krb('krbuser', '192.168.1.1').should_not be_nil
+    u = User.find_by_login('krbuser')
+    u.should_not be_nil
+    u.crypted_password.should be_nil
+  end
+
   it "should reject destroy when user has running instances" do
     user = Factory.create(:tuser)
     deployment = Factory.create(:deployment, :owner => user)


### PR DESCRIPTION
Basic support for web interface SSO authentication with kerberos. It
assumes the HTTP_X_FORWARDED_USER header is passed from the proxy, usually
apache or other web server, in some cases hardware proxy instance with Kerberos
support. After successful verification of HTTP_X_FORWARDED_USER header, this behaves the
same way as ldap. The kerberos authentication is done on the proxy layer due to
security concerns, as the kerberos keytab is often shared among services such as ssh.

Note this is not intended to replace the auth between components, but just to enable
the benefits of SSO as a login into the web interface. There is room for future improvement
too. Maybe even integration with FreeIPA directly into the web interface.
