### PR TITLE
Configurable session timeout + fixed specs

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -468,7 +468,7 @@ class ApplicationController < ActionController::Base
       # compare to last non-backbone reqest time
       last_time = session[:last_active_request]
       if last_time
-        logout if last_time < 15.minutes.ago
+        logout if last_time < SETTINGS_CONFIG[:session][:timeout].minutes.ago
       else
         # This isn't really an active reqest, but
         # boostrapping session time if none set

--- a/src/config/initializers/session_store.rb
+++ b/src/config/initializers/session_store.rb
@@ -28,4 +28,4 @@ Conductor::Application.config.session = {
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information
 # (create the session table with "rake db:sessions:create")
-Conductor::Application.config.session_store :active_record_store, :expire_after => 15.minutes
+Conductor::Application.config.session_store :active_record_store, :expire_after => SETTINGS_CONFIG[:session][:timeout].minutes

--- a/src/config/settings.yml
+++ b/src/config/settings.yml
@@ -19,3 +19,6 @@
   # :oauth:
   #   :consumer_key: consumer_key_here
   #   :consumer_secret: consumer_secret_here
+
+:session:
+  :timeout: 15 # minutes


### PR DESCRIPTION
- 1st commit: Make session expiration timeout configurable. The timeout is settable in settings.yml.
- 2nd commit: Fix session expiration specs. There was a typo in `before` block which should cause them to fail, but there was another error which caused them to pass anyway. One more spec added as a bonus.
