### PR TITLE
BZ 843932 username display

### DIFF
--- a/src/app/controllers/users_controller.rb
+++ b/src/app/controllers/users_controller.rb
@@ -68,7 +68,7 @@ class UsersController < ApplicationController
   def show
     @user = params[:id] ? User.find(params[:id]) : current_user
     require_privilege(Privilege::VIEW, User) unless current_user == @user
-    @title = @user.name
+    @title = @user.name.present? ? @user.name : @user.login
     @quota_resources = @user.quota.quota_resources
     if current_user == user
       current_session.update_session_entities(current_user)
@@ -78,7 +78,7 @@ class UsersController < ApplicationController
       { :name => t('user_groups.index.name'), :sortable => false },
       { :name => t('user_groups.index.type'), :sortable => false },
     ]
-    save_breadcrumb(user_path(@user), @user.name)
+    save_breadcrumb(user_path(@user), @user.name.present? ? @user.name : @user.login)
     @tab_captions = ['Properties']
     @details_tab = 'properties' # currently the only supported details tab
     add_profile_permissions_inline(@user.entity)

--- a/src/app/helpers/users_helper.rb
+++ b/src/app/helpers/users_helper.rb
@@ -18,4 +18,7 @@
 # Likewise, all the methods added will be available for all controllers.
 
 module UsersHelper
+  def format_user_name(user)
+    user.name.present? ? user.name : user.login
+  end
 end

--- a/src/app/models/user.rb
+++ b/src/app/models/user.rb
@@ -94,7 +94,7 @@ class User < ActiveRecord::Base
   before_destroy :ensure_not_running_any_instances
 
   def name
-    "#{first_name} #{last_name}"
+    "#{first_name} #{last_name}".strip
   end
 
   def self.authenticate(username, password, ipaddress)

--- a/src/app/views/layouts/application.html.haml
+++ b/src/app/views/layouts/application.html.haml
@@ -44,7 +44,7 @@
 = content_for :widgets do
   %ul#usermenu
     - if current_user
-      %li= link_to current_user.name, account_path
+      %li= link_to format_user_name(current_user), account_path
       %li= link_to t('masthead.my_account'), account_path
       %li= link_to t('masthead.logout'), logout_path
     - else

--- a/src/app/views/users/show.html.haml
+++ b/src/app/views/users/show.html.haml
@@ -10,7 +10,7 @@
   .content
     #user_card.user_stats_card
       %header.user-card-header
-        %h2= @title
+        %h2= format_user_name(@user)
       .user-card-content
         %dl
           %dt=t'users.show.e-mail'


### PR DESCRIPTION
This fixes https://bugzilla.redhat.com/show_bug.cgi?id=843932 - "UI is quirky with users with no real name"

When using LDAP, it is possible to log in as a user who has no real name specified in LDAP. In Conductor, we then show your name as a blank space, which is broken and looks awful. This patch causes us to fall back to the user's login name if the username is blank.

I added a helper method for this, but I also wanted to use the same logic in some controllers, which caused a little bit of duplication. It would have been a lot simpler to add this to the model, so that `user.name` would do this. However, I think that would be bad, because sometimes when we call `user.name` we do indeed want the user's real name only, like in a table where we show the user's login name in one column and the user's real name in another. Thus, this.

Note that if you enable LDAP authentication to test this, https://www.aeolusproject.org/redmine/issues/3780 will fail, which is seemingly unrelated to this patch.
