### PR TITLE
Bz 852531 login redirect

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -235,7 +235,7 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_back_or_default(default)
-    redirect_to(default || session[:return_to])
+    redirect_to(session[:return_to] || default)
     session[:return_to] = nil
   end
 

--- a/src/app/controllers/user_sessions_controller.rb
+++ b/src/app/controllers/user_sessions_controller.rb
@@ -55,6 +55,6 @@ class UserSessionsController < ApplicationController
   def destroy
     clear_breadcrumbs
     logout
-    redirect_back_or_default login_url
+    redirect_to login_url
   end
 end

--- a/src/features/step_definitions/web_steps.rb
+++ b/src/features/step_definitions/web_steps.rb
@@ -56,7 +56,7 @@ When /^(.*) within (.*[^:]):$/ do |step, parent, table_or_string|
   with_scope(parent) { When "#{step}:", table_or_string }
 end
 
-Given /^(?:|I )am on (.+)$/ do |page_name|
+Given /^(?:|I )(?:am on|visit) (.+)$/ do |page_name|
   page.driver.header 'Accept-Language', 'en-US'
   visit path_to(page_name)
 end

--- a/src/features/user_sessions.feature
+++ b/src/features/user_sessions.feature
@@ -1,0 +1,13 @@
+Feature: User sessions
+  In order to access the site
+  As a user
+  I must first log in
+
+  Scenario: Accessing page without logging in redirects to login page
+    When I visit the images page
+    Then I should be on the login page
+
+  Scenario: Login returns user to previous page
+    Given I visit the images page
+    And I login
+    Then I should be on the images page


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=852531

This ended up being a really easy fix, though I set out trying to solve a challenging problem and thus spent forever walking through session code.

It seems like `redirect_back_or_default` is meant to redirect the user to redirect to `session[:return_to]`, or otherwise the default. But it was actually doing the opposite -- if you passed it a URL, it would redirect there. Otherwise, it would redirect back.

That has to be a bug, because if you wanted to override where it redirected you to (as we do when logging out), you should just redirect them normally.

I added a quick Cucumber test for this.
