### PR TITLE
Always show .obj_actions on Users#show

### DIFF
--- a/src/app/views/users/show.html.haml
+++ b/src/app/views/users/show.html.haml
@@ -1,7 +1,7 @@
 = render :partial => 'layouts/admin_nav'
 %header.page-header
-  - if check_privilege(Privilege::VIEW, User)
-    .obj_actions
+  .obj_actions
+    - if check_privilege(Privilege::VIEW, User)
       .return_to
         =t'return_to'
         = link_to t('users.users'), users_path


### PR DESCRIPTION
The content should be conditional on permissions, but omitting the
container itself causes styling problems.

This is a trivial fix for https://bugzilla.redhat.com/show_bug.cgi?id=853489
