### PR TITLE
Fix backbone session expiration

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -466,7 +466,7 @@ class ApplicationController < ActionController::Base
     # so that it can be tracked from now on
     session[:last_active_request] ||= Time.now
 
-    # compare to last non-backbone reqest time
+    # compare to last non-backbone request time
     logout if session[:last_active_request] < SETTINGS_CONFIG[:session][:timeout].minutes.ago
 
     # FIXME: we really need a better "is it backbone?" test than json format


### PR DESCRIPTION
This renames the `check_session` before filter to `check_session_expiration` and fixes a low-severity bug that I found previously [1]. Hopefully it also makes the filter code a bit more straightforward.

Tested with specs/cukes on F17 + rubygems and F16 + rpm gems. (Some specs fail on F17 + rubygems, as usual.) Also tested manually on F17.

[1] https://github.com/aeolusproject/conductor/pull/19#issuecomment-8094708
