### PR TITLE
BZ851107 New deployment form validation fix

### DIFF
--- a/src/app/views/deployments/_launch_new.html.haml
+++ b/src/app/views/deployments/_launch_new.html.haml
@@ -1,8 +1,6 @@
 = if request.xhr?
   = render :partial => '/layouts/new_notification'
 %header.page-header
-  .obj_actions
-    = link_to t('cancel'), pool_path(@pool), :class => 'button danger', :id => 'cancel_deployment_button'
   %h1.deployments
     = @title
     %span= t('deployments.launch_new.to_pool', :name => "#{@pool.name.capitalize}")
@@ -13,34 +11,35 @@
       = t 'deployments.deployment_details'
 
   .content
-    = form_for :deployment, {:url => launch_time_params_deployments_path, :method => :post, :html => {:class => 'generic'}} do
+    = form_for @deployment, {:url => launch_time_params_deployments_path, :method => :post, :html => {:class => 'generic'}} do |f|
       - if @deployment.errors.any?
         = render 'layouts/error_messages', :object => @deployment
-      = hidden_field :deployment, :pool_id
+      = f.hidden_field :pool_id
       %fieldset
         .field
           %label{:for => 'deployment_name'}
             = t 'deployments.deployment_name'
             %span
               = t 'deployments.deployment_name_subtext'
-          = text_field(:deployment, :name, :class => 'em long')
+          = f.text_field(:name, :class => 'em long')
           %span#name_avail_indicator
 
       %fieldset
         .field
           %label{:for => 'deployable_id'}
-            = t('catalog_entries.index.deployable')
-          = select_tag :deployable_id, options_for_select(@deployables.map {|d| [d.name, d.id]}, params[:deployable_id])
+            = t('catalog_entries.index.catalog_entry')
+          = select_tag :deployable_id, options_from_collection_for_select(@deployables, :id, :name, params[:deployable_id])
 
       %fieldset
         .field
           %label{:for => 'frontend_realm_id'}
             = t('realms.index.realm')
-          = select :deployment, :frontend_realm_id, @realm_choices
-          %div#realm-description
+          = f.collection_select :frontend_realm_id, @realms, :id, :name, :include_blank => t('deployments.launch_new.autoselect')
+          %span#realm-description
 
       %fieldset.options
-        = submit_tag t('.next'), :class => 'button', :id => "next_button", :disabled => true
+        = submit_tag t('.next'), :class => 'button', :id => "next_button"
+        = link_to t('cancel'), pool_path(@pool), :class => 'button danger', :id => 'cancel_deployment_button'
 
 
 :javascript
@@ -49,23 +48,10 @@
   // Might be nice to build something in application.js to guard against this, and that also
   // introduces a ~250ms buffer so we don't do a lookup on every single keystroke...
   $(document).ready(function () {
-    $('#deployable_id').change(function(){
-      if($(this).val() !== 'other'){
-        $('#deployable-url-section').hide();
-      }else{
-        $('#deployable-url-section').show();
-      }
-    });
     $('#deployment_name').blur(function(e) {
       e.preventDefault();
       $.get('#{check_name_deployments_path}', {name: $('#deployment_name').val() }, function(data) {
         $('#name_avail_indicator').html(data == "false" ? "#{t'deployments.launch_new.already_in_use'}" : "#{t'deployments.launch_new.name_available'}");
-        if(data == "true" && $('#next_button').is(':disabled')){
-         $('#next_button').removeAttr('disabled');
-        }else if(data == "true" && $('#next_button').is_not(':disabled')){
-        }else{
-         $('#next_button').attr("disabled", "disabled");
-        }
       });
     });
 

--- a/src/app/views/deployments/_overview.html.haml
+++ b/src/app/views/deployments/_overview.html.haml
@@ -42,7 +42,7 @@
           .field
             = label_tag :realm, t('realms.index.realm')
             .input
-              = select :deployment, :frontend_realm_id, @realm_choices
+              = collection_select :deployment, :frontend_realm_id, @realms, :id, :name, :include_blank => t('deployments.launch_new.autoselect')
               %div#realm-description
 
         .field

--- a/src/features/deployment.feature
+++ b/src/features/deployment.feature
@@ -65,6 +65,21 @@ Feature: Manage Deployments
     Then I should see "Created"
     Then I should see "mynewdeployment"
 
+  Scenario: Validate Deployment when creating new
+    Given a pool "mockpool" exists
+    And "mockpool" has catalog "test"
+    And "test" has catalog_entry "test_catalog_entry"
+    And there is "front_hwp1" conductor hardware profile
+    And there is "front_hwp2" conductor hardware profile
+    And there is mock provider account "my_mock_provider"
+    And there is a provider account "my_mock_provider" related to pool family "default"
+    When I am viewing the pool "mockpool"
+    And I follow "new_deployment_button"
+    Then I should be on the launch new deployments page
+    When I select "test_catalog_entry" from "deployable_id"
+    When I press "next_button"
+    Then I should see "Name can't be blank"
+
   Scenario: Launch a deployment in a disabled pool
     Given a pool "Disabled" exists and is disabled
     And there is "front_hwp1" conductor hardware profile


### PR DESCRIPTION
The Deployment is now validated after clicking next and proper error message is displayed if validation fails.
Next button is no more disabled. Js only evaluates if the name is available and displays message next to input.

https://bugzilla.redhat.com/show_bug.cgi?id=851107
