### PR TITLE
RM 3562 - pool families api

### DIFF
--- a/src/app/controllers/pool_families_controller.rb
+++ b/src/app/controllers/pool_families_controller.rb
@@ -17,6 +17,8 @@
 require 'will_paginate/array'
 
 class PoolFamiliesController < ApplicationController
+  include QuotaAware
+
   before_filter :require_user
   before_filter :set_params_and_header, :only => [:index, :show]
   before_filter :load_pool_families, :only =>[:index, :show]
@@ -29,6 +31,9 @@ class PoolFamiliesController < ApplicationController
     respond_to do |format|
       format.html
       format.js { render :partial => 'list' }
+      format.xml do
+        render :partial => 'list.xml'
+      end
     end
   end
 
@@ -39,16 +44,26 @@ class PoolFamiliesController < ApplicationController
   end
 
   def create
+    set_quota_param(:pool_family)
     @pool_family = PoolFamily.new(params[:pool_family])
+    @pool_family.quota = @quota = Quota.new
     require_privilege(Privilege::CREATE, PoolFamily)
+    set_quota(@pool_family)
 
-    unless @pool_family.save
-      flash.now[:warning] = t"pool_families.flash.warning.creation_failed"
-      render :new and return
-    else
-      @pool_family.assign_owner_roles(current_user)
-      flash[:notice] = t"pool_families.flash.notice.added"
-      redirect_to pool_families_path
+    respond_to do |format|
+      if @pool_family.save
+        @pool_family.assign_owner_roles(current_user)
+        flash[:notice] = t"pool_families.flash.notice.added"
+        format.html { redirect_to pool_families_path }
+        format.xml {
+          render :show, :locals => { :pool_family => @pool_family }}
+      else
+        flash.now[:warning] = t"pool_families.flash.warning.creation_failed"
+        format.html { render :new and return }
+        format.xml { render :template => 'api/validation_error',
+          :locals => { :errors => @pool_family.errors },
+          :status => :bad_request}
+      end
     end
   end
 
@@ -60,15 +75,28 @@ class PoolFamiliesController < ApplicationController
   end
 
   def update
+    set_quota_param(:pool_family)
     @pool_family = PoolFamily.find(params[:id])
     require_privilege(Privilege::MODIFY, @pool_family)
+    set_quota(@pool_family)
 
-    unless @pool_family.update_attributes(params[:pool_family])
-      flash[:error] = t "pool_families.flash.error.not_updated"
-      render :action => 'edit' and return
-    else
-      flash[:notice] = t "pool_families.flash.notice.updated"
-      redirect_to pool_families_path
+    respond_to do |format|
+      if @pool_family.update_attributes(params[:pool_family])
+        format.html {
+          flash[:notice] = t "pool_families.flash.notice.updated"
+          redirect_to pool_families_path
+        }
+        format.xml {
+          render :show, :locals => { :pool_family => @pool_family } }
+      else
+        format.html {
+          flash[:error] = t "pool_families.flash.error.not_updated"
+          render :action => 'edit' and return
+        }
+        format.xml { render :template => 'api/validation_error',
+          :locals => { :errors => @pool_family.errors },
+          :status => :bad_request}
+      end
     end
   end
 
@@ -90,6 +118,7 @@ class PoolFamiliesController < ApplicationController
         end
         render :partial => @view and return
       end
+      format.xml { render :show, :locals => { :pool_family => @pool_family } }
     end
   end
 
@@ -104,7 +133,16 @@ class PoolFamiliesController < ApplicationController
       flash[:error] = t "pool_families.flash.error.not_deleted"
     end
 
-    redirect_to pool_families_path
+    respond_to do |format|
+      format.html { redirect_to pool_families_path }
+      format.xml {
+        if flash[:error].present?
+          raise(Aeolus::Conductor::API::Error.new(500, flash[:error]))
+        else
+          render :destroy, :locals => { :pool_family_id => pool_family.id }
+        end
+      }
+    end
   end
 
   def add_provider_accounts

--- a/src/app/util/quota_aware.rb
+++ b/src/app/util/quota_aware.rb
@@ -1,0 +1,42 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# In XML requests, the quota is embedded as a node in the container object,
+# because more than one root nodes are not allowed.
+#
+# In other types of requests, the quota param is in the "root" and the
+# controllers are written to expect that.
+#
+# For XML requests we need to move the quota params back to the "root".
+module QuotaAware
+
+  def set_quota_param(node_where_quota_is_embedded)
+    if !params.has_key? :quota and !params[node_where_quota_is_embedded][:quota].nil?
+      params[:quota] = params[node_where_quota_is_embedded][:quota]
+      params[node_where_quota_is_embedded].delete(:quota)
+    end
+  end
+
+  def set_quota(quota_aware_model)
+    limit = if params.has_key? :quota and not params[:unlimited_quota]
+              params[:quota][:maximum_running_instances]
+            else
+              nil
+            end
+    quota_aware_model.quota.set_maximum_running_instances(limit)
+  end
+
+end

--- a/src/app/views/api/entrypoint/index.xml.haml
+++ b/src/app/views/api/entrypoint/index.xml.haml
@@ -2,6 +2,7 @@
 %api{:href => api_url}
   %images{:href => api_images_url}
   %builds{:href => api_builds_url}
+  %pool_families{:href => api_pool_families_url}
   %pools{:href => api_pools_url}
   %provider_images{:href => api_provider_images_url}
   %target_images{:href => api_target_images_url}

--- a/src/app/views/pool_families/_detail.xml.haml
+++ b/src/app/views/pool_families/_detail.xml.haml
@@ -1,0 +1,7 @@
+!!! XML
+%pool_family{:id => pool_family.id, :url => api_pool_family_url(pool_family)}
+  %name= pool_family.name
+  %quota= pool_family.quota.maximum_running_instances
+  %pools
+    - pool_family.pools.each do |pool|
+      %pool{:id => pool.id, :href => api_pool_url(pool.id)}

--- a/src/app/views/pool_families/_list.xml.haml
+++ b/src/app/views/pool_families/_list.xml.haml
@@ -1,0 +1,4 @@
+!!! XML
+%pool_families
+  - @pool_families.each do |fam|
+    %pool_family{:id => fam.id, :href => api_pool_family_url(fam)}

--- a/src/app/views/pool_families/destroy.xml.haml
+++ b/src/app/views/pool_families/destroy.xml.haml
@@ -1,0 +1,3 @@
+!!! XML
+%pool_family{:id => pool_family_id}
+  %status="DELETED"

--- a/src/app/views/pool_families/show.xml.haml
+++ b/src/app/views/pool_families/show.xml.haml
@@ -1,0 +1,2 @@
+!!! XML
+=render 'detail', :pool_family => pool_family

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -298,6 +298,7 @@ Conductor::Application.routes.draw do
     resources :provider_types, :only => [:index, :show]
     resources :hardware_profiles, :only => [:index, :show, :destroy, :create]
     resources :pools, :only => [:index, :show, :create, :update, :destroy]
+    resources :pool_families, :only => [:index, :show, :create, :update, :destroy]
   end
 
   #match 'matching_profiles', :to => '/hardware_profiles/matching_profiles/:hardware_profile_id/provider/:provider_id', :controller => 'hardware_profiles', :action => 'matching_profiles', :conditions => { :method => :get }, :as =>'matching_profiles'

--- a/src/spec/controllers/api/entrypoint_controller_spec.rb
+++ b/src/spec/controllers/api/entrypoint_controller_spec.rb
@@ -43,10 +43,11 @@ describe Api::EntrypointController do
         api['images']['href'].should == api_images_url
         api['builds']['href'].should == api_builds_url
         api['target_images']['href'].should == api_target_images_url
+        api['pools']['href'].should == api_pools_url
+        api['pool_families']['href'].should == api_pool_families_url
         api['provider_images']['href'].should == api_provider_images_url
         api['providers']['href'].should == api_providers_url
         api['provider_accounts']['href'].should == api_provider_accounts_url
-      end
     end
   end
 end

--- a/src/spec/controllers/pool_families_controller_spec.rb
+++ b/src/spec/controllers/pool_families_controller_spec.rb
@@ -72,4 +72,173 @@ describe PoolFamiliesController do
     PoolFamily.find_by_name('updated pool family').should be_nil
     response.should render_template('layouts/error')
   end
+
+  context "API" do
+    render_views
+
+    before do
+      accept_xml
+      mock_warden(@admin)
+      @test_name = "spec-pool-family-1"
+    end
+
+    def assert_pool_api_success_response(name, quota, number_of_pools)
+      response.should be_success
+      response.should have_content_type("application/xml")
+      response.body.should be_xml
+      xml = Nokogiri::XML(response.body)
+      xml.xpath("/pool_family/name").text.should == name
+      xml.xpath("/pool_family/quota").text.should == quota
+      pool_set = xml.xpath('/pool_family/pools/pool')
+      pool_set.size.should be_eql(number_of_pools.to_i)
+    end
+
+    describe "#index" do
+
+      it "get index" do
+        get :index
+
+        response.should be_success
+        response.should have_content_type("application/xml")
+        response.body.should be_xml
+        xml = Nokogiri::XML(response.body)
+        # default
+        xml.xpath("/pool_families/pool_family").size.should be_eql(1)
+      end
+    end
+
+    describe "#create" do
+      it "post with all expected params" do
+        xmldata = "
+        <pool_family>
+          <name>#{@test_name}</name>
+          <quota>
+            <maximum_running_instances>1001</maximum_running_instances>
+          </quota>
+        </pool_family>"
+        post :create, Hash.from_xml(xmldata)
+
+        assert_pool_api_success_response(@test_name, "1001", 0)
+      end
+
+      it "post missing name parameter should result in error message" do
+        xmldata = "
+        <pool_family>
+          <!--<name>#{@test_name}</name>-->
+          <quota>
+            <maximum_running_instances>1001</maximum_running_instances>
+          </quota>
+        </pool_family>"
+        post :create, Hash.from_xml(xmldata)
+
+        response.status.should be_eql(400)
+        response.should have_content_type("application/xml")
+        response.body.should be_xml
+      end
+    end
+
+
+     describe "#show" do
+      it "show an existing pool family" do
+        @pool_family = FactoryGirl.create :pool_family
+        Aeolus::Image::Warehouse::Image.stub(:by_environment).with(@pool_family.name).and_return([])
+        FactoryGirl.create(:pool, :name => "pool1", :pool_family => @pool_family)
+        FactoryGirl.create(:pool, :name => "pool2", :pool_family => @pool_family)
+        FactoryGirl.create(:pool, :name => "pool3", :pool_family => @pool_family)
+
+        get :show, :id => @pool_family.id
+
+        assert_pool_api_success_response(@pool_family.name,
+                                         "#{@pool_family.quota.maximum_running_instances}",
+                                         3)
+      end
+
+      it "show a missing pool family" do
+        get :show, :id => -1
+
+        response.status.should be_eql(404)
+        response.should have_content_type("application/xml")
+        response.body.should be_xml
+      end
+    end
+
+    describe "#update" do
+
+      it "update with all expected params" do
+        Aeolus::Image::Warehouse::Image.stub(:by_environment).with("#{@test_name}").and_return([])
+        xmldata = "
+        <pool_family>
+          <name>#{@test_name}</name>
+        </pool_family>"
+        post :create, Hash.from_xml(xmldata)
+
+        assert_pool_api_success_response(@test_name, "", 0)
+
+        xml = Nokogiri::XML(response.body)
+        pool_family_id = xml.xpath("/pool_family/@id").text
+
+        xmldata = "
+        <pool_family>
+          <name>pool-family-updated</name>
+          <quota>
+            <maximum_running_instances>1002</maximum_running_instances>
+          </quota>
+        </pool_family>"
+        put :update, :id => pool_family_id, :pool_family => Hash.from_xml(xmldata)["pool_family"]
+
+        assert_pool_api_success_response("pool-family-updated", "1002", 0)
+      end
+
+      it "update missing pool family" do
+        xmldata = "<pool_family><name>missing-pool</name></pool_family>"
+        put :update, :id => -1, :pool_family => Hash.from_xml(xmldata)["pool_family"]
+
+        response.status.should be_eql(404)
+        response.should have_content_type("application/xml")
+        response.body.should be_xml
+      end
+
+      it "update with blank name" do
+        @pool_family = FactoryGirl.create :pool_family
+        xmldata = "<pool_family><name></name></pool_family>"
+        put :update, :id => @pool_family.id, :pool_family => Hash.from_xml(xmldata)["pool_family"]
+
+        response.status.should be_eql(400)
+        response.should have_content_type("application/xml")
+        response.body.should be_xml
+      end
+    end
+
+    describe "#destroy" do
+
+      it "delete an existing pool family" do
+        @pool_family = FactoryGirl.create :pool_family
+        get :destroy, :id => @pool_family.id
+
+        response.status.should be_eql(200)
+        response.should have_content_type("application/xml")
+        response.body.should be_xml
+        xml = Nokogiri::XML(response.body)
+        xml.xpath("/pool_family/@id").text.should == "#{@pool_family.id}"
+        xml.xpath("/pool_family/status").text.should == "DELETED"
+      end
+
+      it "delete a missing pool family should throw error" do
+        get :destroy, :id => -1
+
+        response.status.should be_eql(404)
+        response.should have_content_type("application/xml")
+        response.body.should be_xml
+      end
+
+      it "delete default pool family should throw error" do
+        @pool_family = FactoryGirl.create :pool_family
+        get :destroy, :id => 1
+
+        response.status.should be_eql(500)
+        response.should have_content_type("application/xml")
+        response.body.should be_xml
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://www.aeolusproject.org/redmine/issues/3562

Implemented create, index, show, update, and destroy.
Added pool_families to api entrypoint.

In a follow-on patch, I'm planning to modify PoolsController and ProviderAccountsController to be also QuotaAware.

Rebased and shorten error validation lines based off Jay's feedback in https://github.com/aeolusproject/conductor/pull/30
