### PR TITLE
BZ 783128 - Renames "Image URI" to "Provider's Image ID"

### DIFF
--- a/src/app/views/images/_status.html.mustache
+++ b/src/app/views/images/_status.html.mustache
@@ -41,7 +41,7 @@
               <%= t('images.show.image_uuid') %>
             </th>
             <th>
-              <%= t('images.show.image_uri') %>
+              <%= t('images.show.providers_image_id') %>
             </th>
             <th class="image_controls"></th>
           </tr></thead>

--- a/src/config/locales/en.yml
+++ b/src/config/locales/en.yml
@@ -959,7 +959,7 @@ en:
       build: Build
       delete: Delete
       account: Account
-      image_uri: Image URI
+      providers_image_id: "Provider's Image ID"
       provider: Provider
       build_date: Build Completion Date
       latest: Latest


### PR DESCRIPTION
Beyond the fact that it's not actually a URI at all, it's unclear
what it is. We decided "Provider's Image ID" was clearer.

https://bugzilla.redhat.com/show_bug.cgi?id=783128
