### PR TITLE
Adds QuotaAware to Provider Account create and update

### DIFF
--- a/src/app/controllers/provider_accounts_controller.rb
+++ b/src/app/controllers/provider_accounts_controller.rb
@@ -15,6 +15,7 @@
 #
 
 class ProviderAccountsController < ApplicationController
+  include QuotaAware
   before_filter :require_user
   before_filter :load_provider, :only => [:index]
   before_filter :load_accounts, :only => [:index,:show]
@@ -88,11 +89,11 @@ class ProviderAccountsController < ApplicationController
     params[:provider_account][:provider_id] = @provider.id
     @providers = Provider.all
     credentials_hash = credentials_hash_prepare
+    set_quota_param(:provider_account)
     @provider_account = ProviderAccount.new(params[:provider_account])
     @provider_account.credentials_hash = credentials_hash
     @provider_account.quota = @quota = Quota.new
-    limit = params[:quota][:maximum_running_instances] if params[:quota]
-    @provider_account.quota.set_maximum_running_instances(limit)
+    set_quota(@provider_account)
     @provider_account.pool_families << PoolFamily.default
     begin
       if @provider_account.save
@@ -143,8 +144,8 @@ class ProviderAccountsController < ApplicationController
     require_privilege(Privilege::MODIFY,@provider_account)
     @quota = @provider_account.quota
     @providers = Provider.find(:all)
-    limit = params[:quota][:maximum_running_instances] if params[:quota]
-    @provider_account.quota.set_maximum_running_instances(limit)
+    set_quota_param(:provider_account)
+    set_quota(@provider_account)
     credentials_hash = credentials_hash_prepare
     @provider_account.attributes = params[:provider_account]
     @provider_account.credentials_hash= credentials_hash

--- a/src/spec/controllers/provider_accounts_controller_spec.rb
+++ b/src/spec/controllers/provider_accounts_controller_spec.rb
@@ -267,6 +267,11 @@ describe ProviderAccountsController do
               it "should have correct provider account" do
                 xml_provider_account.xpath('@href').text.should be_eql(api_provider_account_url(provider_account))
               end
+              context "quota" do
+                it "should have correct quota node" do
+                  xml_provider_account.xpath('//quota').attr('maximum_running_instances').text.should be_eql(provider_account.quota.maximum_running_instances.to_s)
+                end
+              end
               context "credentials" do
 
                 context "of mock provider" do

--- a/src/spec/requests/api/provider_accounts_spec.rb
+++ b/src/spec/requests/api/provider_accounts_spec.rb
@@ -27,7 +27,7 @@ describe "ProviderAccounts" do
     context "with valid" do
       context "mock provider account XML" do
         let(:xml) do
-          "<provider_account><label>mockaccount</label><credentials><username>mockuser</username><password>mockpassword</password></credentials></provider_account>"
+          "<provider_account><label>mockaccount</label><credentials><username>mockuser</username><password>mockpassword</password></credentials><quota><maximum_running_instances>100</maximum_running_instances></quota></provider_account>"
         end
         let(:provider) { FactoryGirl.create(:mock_provider) }
 
@@ -44,6 +44,7 @@ describe "ProviderAccounts" do
             subject.xpath('//provider_account/credentials/username').text.should be_eql("mockuser")
             subject.xpath('//provider_account/credentials/password').size.should be_eql(1)
             subject.xpath('//provider_account/credentials/password').text.should be_eql("mockpassword")
+            subject.xpath('//provider_account/quota').attr('maximum_running_instances').text.should be_eql("100")
           end
         end
       end
@@ -60,6 +61,7 @@ describe "ProviderAccounts" do
               <x509private><![CDATA[ec2x509private]]></x509private>
               <x509public><![CDATA[ec2x509public]]></x509public>
             </credentials>
+            <quota><maximum_running_instances>100</maximum_running_instances></quota>
           </provider_account>"
         end
         let(:provider) { DeltaCloud.stub(:valid_credentials?).and_return(true); FactoryGirl.create(:ec2_provider) }
@@ -79,6 +81,7 @@ describe "ProviderAccounts" do
             subject.xpath('//provider_account/credentials/password').text.should be_eql("ec2password")
             subject.xpath('//provider_account/credentials/x509private').size.should be_eql(1)
             subject.xpath('//provider_account/credentials/x509private').text.should be_eql("ec2x509private")
+            subject.xpath('//provider_account/quota').attr('maximum_running_instances').text.should be_eql("100")
           end
         end
       end
@@ -142,7 +145,7 @@ describe "ProviderAccounts" do
       context "with valid" do
         context "mock provider account XML" do
           let(:xml) do
-            "<provider_account><label>mockaccount</label><credentials><username>mockuser</username><password>mockpassword</password></credentials></provider_account>"
+            "<provider_account><label>mockaccount</label><credentials><username>mockuser</username><password>mockpassword</password></credentials><quota><maximum_running_instances>100</maximum_running_instances></quota></provider_account>"
           end
           let(:provider) { FactoryGirl.create(:mock_provider) }
           let(:provider_account) { FactoryGirl.create(:mock_provider_account, :provider => provider) }
@@ -160,6 +163,7 @@ describe "ProviderAccounts" do
               subject.xpath('//provider_account/credentials/username').text.should be_eql("mockuser")
               subject.xpath('//provider_account/credentials/password').size.should be_eql(1)
               subject.xpath('//provider_account/credentials/password').text.should be_eql("mockpassword")
+              subject.xpath('//provider_account/quota').attr('maximum_running_instances').text.should be_eql("100")
             end
           end
         end
@@ -176,6 +180,7 @@ describe "ProviderAccounts" do
                            <x509private><![CDATA[ec2x509private]]></x509private>
                            <x509public><![CDATA[ec2x509public]]></x509public>
                          </credentials>
+                         <quota><maximum_running_instances>100</maximum_running_instances></quota>
                        </provider_account>"
           end
           let(:provider) { FactoryGirl.create(:ec2_provider) }
@@ -200,6 +205,7 @@ describe "ProviderAccounts" do
               subject.xpath('//provider_account/credentials/x509private').text.should be_eql("ec2x509private")
               subject.xpath('//provider_account/credentials/x509public').size.should be_eql(1)
               subject.xpath('//provider_account/credentials/x509public').text.should be_eql("ec2x509public")
+              subject.xpath('//provider_account/quota').attr('maximum_running_instances').text.should be_eql("100")
             end
           end
         end


### PR DESCRIPTION
This changes handling of quota params in ProviderAccountsController for create and update actions to use QuotaAware module. This ensures that quotas are handled consistently and XML input uses the similar format.
