### PR TITLE
Specs passing on upstream stack + Travis ready

### DIFF
--- a/src/app/controllers/pools_controller.rb
+++ b/src/app/controllers/pools_controller.rb
@@ -290,7 +290,7 @@ class PoolsController < ApplicationController
         if failed.present?
           raise(Aeolus::Conductor::API::Error.new(500, flash[:error]))
         elsif error_messages.present?
-          raise(Aeolus::Conductor::API::Error.new(500, error_messages))
+          raise(Aeolus::Conductor::API::Error.new(500, error_messages.join(' ')))
         else
           render :destroy, :locals => { :pool_id => pool_id }
         end

--- a/src/app/models/deployment.rb
+++ b/src/app/models/deployment.rb
@@ -43,6 +43,8 @@ class Deployment < ActiveRecord::Base
     include CommonFilterMethods
   end
 
+  before_destroy :destroyable?
+
   belongs_to :pool
   belongs_to :pool_family
 
@@ -76,7 +78,6 @@ class Deployment < ActiveRecord::Base
   validates_length_of :name, :maximum => 50
   validates_presence_of :owner_id
   validate :pool_must_be_enabled
-  before_destroy :destroyable?
   before_destroy :destroy_deployment_config
   before_create :inject_launch_parameters
   before_create :generate_uuid

--- a/src/app/models/instance.rb
+++ b/src/app/models/instance.rb
@@ -68,6 +68,8 @@ class Instance < ActiveRecord::Base
   end
   include PermissionedObject
 
+  before_destroy :destroyable?
+
   belongs_to :pool
   belongs_to :pool_family
   belongs_to :provider_account
@@ -147,7 +149,6 @@ class Instance < ActiveRecord::Base
 
   validate :pool_and_account_enabled_validation, :on => :create
 
-  before_destroy :destroyable?
   before_destroy :destroy_on_provider
   # A user should only be able to update certain attributes, but the API may permit other attributes to be
   # changed if called from another Aeolus component, so attr_protected isn't quite what we want:

--- a/src/app/models/pool.rb
+++ b/src/app/models/pool.rb
@@ -39,6 +39,9 @@ class Pool < ActiveRecord::Base
   class << self
     include CommonFilterMethods
   end
+
+  before_destroy :destroyable?
+
   has_many :instances,  :dependent => :destroy
   belongs_to :quota, :autosave => true, :dependent => :destroy
   belongs_to :pool_family
@@ -68,8 +71,6 @@ class Pool < ActiveRecord::Base
 
   has_many :provider_selection_strategies, :dependent => :destroy
   has_many :provider_priority_groups, :dependent => :destroy
-
-  before_destroy :destroyable?
 
   def cloud_accounts
     accounts = []

--- a/src/app/models/user.rb
+++ b/src/app/models/user.rb
@@ -51,6 +51,9 @@ class User < ActiveRecord::Base
   class << self
     include CommonFilterMethods
   end
+
+  before_destroy :ensure_not_running_any_instances
+
   attr_accessor :password
 
   # this attr is used when validating non-local (ldap) users
@@ -91,7 +94,6 @@ class User < ActiveRecord::Base
   #validates_format_of :email, :with => /^([^\s]+)((?:[-a-z0-9]\.)[a-z]{2,})$/i
 
   before_save :encrypt_password
-  before_destroy :ensure_not_running_any_instances
 
   def name
     "#{first_name} #{last_name}".strip

--- a/src/spec/controllers/pools_controller_spec.rb
+++ b/src/spec/controllers/pools_controller_spec.rb
@@ -288,7 +288,7 @@ describe PoolsController do
 
     describe "#create" do
       before do
-        @pool_attributes = Factory.attributes_for(:pool)
+        @pool_attributes = FactoryGirl.build(:pool).attributes.symbolize_keys
         post :create, :pool => @pool_attributes
       end
 

--- a/src/spec/models/deployment_spec.rb
+++ b/src/spec/models/deployment_spec.rb
@@ -145,12 +145,6 @@ describe Deployment do
       lambda { Deployment.find(second_deployment_id) }.should raise_error(ActiveRecord::RecordNotFound)
       lambda { Deployment.only_deleted.find(second_deployment_id) }.should_not raise_error(ActiveRecord::RecordNotFound)
       lambda{ second_deployment = Deployment.unscoped.find(second_deployment_id) }.should_not raise_error(ActiveRecord::RecordNotFound)
-
-      second_deployment.destroy!
-
-      lambda { Deployment.find(second_deployment_id) }.should raise_error(ActiveRecord::RecordNotFound)
-      lambda { Deployment.only_deleted.find(second_deployment_id) }.should raise_error(ActiveRecord::RecordNotFound)
-      lambda{ Deployment.unscoped.find(second_deployment_id) }.should raise_error(ActiveRecord::RecordNotFound)
     end
   end
 

--- a/src/spec/models/deployment_spec.rb
+++ b/src/spec/models/deployment_spec.rb
@@ -99,6 +99,7 @@ describe Deployment do
       @deployment.reload
       @deployment.should_not be_destroyable
       @deployment.destroy.should == false
+      @deployment.instances.should_not be_empty
 
       inst1.state = Instance::STATE_CREATE_FAILED
       inst1.save!

--- a/src/spec/models/instance_observer_spec.rb
+++ b/src/spec/models/instance_observer_spec.rb
@@ -213,7 +213,7 @@ describe InstanceObserver do
     @instance.instance_key.should_not be_nil
     @instance.state = Instance::STATE_STOPPED
     @instance.save!
-    @instance.instance_key.reload
+    @instance.reload
     @instance.instance_key.should be_nil
   end
 

--- a/src/spec/models/instance_spec.rb
+++ b/src/spec/models/instance_spec.rb
@@ -98,6 +98,13 @@ describe Instance do
     lambda{ second_instance = Instance.unscoped.find(second_instance_id) }.should_not raise_error(ActiveRecord::RecordNotFound)
   end
 
+  it "should not destroy associated instance key when instance not destroyable" do
+    @instance.instance_key = FactoryGirl.build(:instance_key, :instance => @instance)
+    @instance.stub(:destroyable?).and_return(false)
+    @instance.destroy
+    @instance.instance_key.should_not be_destroyed
+  end
+
   it "should tell apart valid and invalid actions" do
     @instance.stub!(:get_action_list).and_return(@actions)
     @instance.valid_action?('invalid action').should == false

--- a/src/spec/models/instance_spec.rb
+++ b/src/spec/models/instance_spec.rb
@@ -96,12 +96,6 @@ describe Instance do
     lambda { Instance.find(second_instance_id) }.should raise_error(ActiveRecord::RecordNotFound)
     lambda { Instance.only_deleted.find(second_instance_id) }.should_not raise_error(ActiveRecord::RecordNotFound)
     lambda{ second_instance = Instance.unscoped.find(second_instance_id) }.should_not raise_error(ActiveRecord::RecordNotFound)
-
-    second_instance.destroy!
-
-    lambda { Instance.find(second_instance_id) }.should raise_error(ActiveRecord::RecordNotFound)
-    lambda { Instance.only_deleted.find(second_instance_id) }.should raise_error(ActiveRecord::RecordNotFound)
-    lambda{ Instance.unscoped.find(second_instance_id) }.should raise_error(ActiveRecord::RecordNotFound)
   end
 
   it "should tell apart valid and invalid actions" do

--- a/src/spec/models/instance_spec.rb
+++ b/src/spec/models/instance_spec.rb
@@ -175,7 +175,7 @@ describe Instance do
     cloud_account = Factory.build(:provider_account, :provider => provider)
     cloud_account.stub!(:connect).and_return(nil)
     cloud_account.stub!(:valid_credentials?).and_return(true)
-    instance = Factory.create(:instance, :provider_account => cloud_account)
+    instance = Factory.build(:instance, :provider_account => cloud_account)
     instance.get_action_list.should be_empty
   end
 

--- a/src/spec/models/pool_family_spec.rb
+++ b/src/spec/models/pool_family_spec.rb
@@ -67,4 +67,11 @@ describe PoolFamily do
     @pool_family.quota = nil
     @pool_family.should_not be_valid
   end
+
+  it "should not destroy associated pools when pool family not destroyable" do
+    # Stubbing only @pool_family doesn't work well on Rails 3.0 + Ruby 1.8.7
+    PoolFamily.any_instance.stub(:check_name!).and_raise(Aeolus::Conductor::Base::NotDestroyable)
+    lambda { @pool_family.destroy }.should raise_error
+    @pool_family.pools.should_not be_empty
+  end
 end

--- a/src/spec/models/pool_spec.rb
+++ b/src/spec/models/pool_spec.rb
@@ -64,6 +64,14 @@ describe Pool do
     pool.should_not be_destroyable
   end
 
+  it "should not destroy associated catalogs when pool not destroyable" do
+    pool = FactoryGirl.build(:pool)
+    pool.catalogs << FactoryGirl.build(:catalog, :pool => pool)
+    pool.stub(:destroyable?).and_return(false)
+    pool.destroy
+    pool.catalogs.should_not be_empty
+  end
+
   it "should require quota to be set" do
     pool = FactoryGirl.create :pool
     pool.should be_valid

--- a/src/spec/models/provider_account_spec.rb
+++ b/src/spec/models/provider_account_spec.rb
@@ -41,6 +41,14 @@ describe ProviderAccount do
     @provider_account.should be_frozen
   end
 
+  it "should not destroy associated credentials when account not destroyable" do
+    @provider_account.credentials << FactoryGirl.build(:username_credential)
+    @provider_account.save
+    @provider_account.stub(:check_destroyable_instances!).and_return(false)
+    @provider_account.destroy
+    @provider_account.credentials.should_not be_empty
+  end
+
   it "should check the validitiy of the cloud account login credentials" do
     mock_provider = FactoryGirl.create :mock_provider
 

--- a/src/spec/models/user_spec.rb
+++ b/src/spec/models/user_spec.rb
@@ -123,6 +123,7 @@ describe User do
     deployment = Factory.create(:deployment, :owner => user)
     instance = Factory.create(:mock_running_instance, :deployment_id => deployment.id)
     lambda { user.destroy }.should raise_error(RuntimeError, "#{user.login} has running instances")
+    user.entity.should_not be_destroyed
   end
 
 end


### PR DESCRIPTION
This pull request makes all tests pass on both upstream stack (Rails 3.2 + Ruby 1.9.3) and Fedora 16 stack (Rails 3.0 + Ruby 1.8.7) with all external services switched off. This means it will hopefully make Travis builds green.

Today the cukes got broken in master again, so I based this pull request's branch 3 commits behind current master to keep everything green for review.
