### PR TITLE
BZ #855717: fix Ruby 1.8 compatibility

### DIFF
--- a/src/lib/provider_selection/chainable_strategy.rb
+++ b/src/lib/provider_selection/chainable_strategy.rb
@@ -23,7 +23,7 @@ module ProviderSelection
         @strategies = strategies
         options ||= {}
 
-        if self.class.methods.include?(:default_options)
+        if self.class.method_names.include?('default_options')
           @options = self.class.default_options.with_indifferent_access.merge(options)
         else
           @options = options


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=855717

In Ruby 1.8 the Object#methods returns an array of string, while in Ruby 1.9 it returns an array of symbols.
Rails provides Object#method_names which always returns an array of string.
