### PR TITLE
Refactor Ruby 1.8 compatibility fix in provider selection

### DIFF
--- a/src/lib/provider_selection/chainable_strategy.rb
+++ b/src/lib/provider_selection/chainable_strategy.rb
@@ -23,7 +23,7 @@ module ProviderSelection
         @strategies = strategies
         options ||= {}
 
-        if self.class.method_names.include?('default_options')
+        if self.class.methods.map(&:to_s).include?('default_options')
           @options = self.class.default_options.with_indifferent_access.merge(options)
         else
           @options = options


### PR DESCRIPTION
The change was introduced by 7f26b8846b36515a6648b3f94ab24036471d8370 which is using a Rails method to solve an incompatility issue between 1.8 and 1.9.
It's better no to couple Rails with the provider selection because in the future we may want to seperate the provider selection code into a separate gem.
