### PR TITLE
Quick header button fixes

### DIFF
--- a/src/app/stylesheets/_header.scss
+++ b/src/app/stylesheets/_header.scss
@@ -19,7 +19,7 @@ header#header {
   	list-style:none;
   	  li {
   		  background-color: rgba(25, 25, 30, 0.4);
-  		  border:.2em solid rgba(205, 206, 208, 0.4);
+  		  border: none;
         -webkit-border-radius: .5em;
         -moz-border-radius: .5em;
         border-radius: .5em;

--- a/src/app/stylesheets/_header.scss
+++ b/src/app/stylesheets/_header.scss
@@ -12,6 +12,10 @@ header#header {
     bottom: 15px;
   }
 
+  .header-widget {
+    float: left;
+  }
+
   #widget-container {
     top:27px;
 

--- a/src/app/views/layouts/application.html.haml
+++ b/src/app/views/layouts/application.html.haml
@@ -47,11 +47,11 @@
 = content_for :widgets do
   %ul#usermenu
     - if current_user
-      %li= link_to format_user_name(current_user), account_path
-      %li= link_to t('masthead.my_account'), account_path
-      %li= link_to t('masthead.logout'), logout_path
+      %li.header-widget= link_to format_user_name(current_user), account_path
+      %li.header-widget= link_to t('masthead.my_account'), account_path
+      %li.header-widget= link_to t('masthead.logout'), logout_path
     - else
-      %li= link_to t('masthead.login'), login_path
+      %li.header-widget= link_to t('masthead.login'), login_path
 
 = content_for :content do
   = render :partial => '/layouts/new_notification' if flash.present? or content_for?(:error_messages)


### PR DESCRIPTION
This is a pair of really minor patches to fix up the buttons in our header.

They had an inexplicable gray border, and were missing the `header-widget` class that Katello used.
