### PR TITLE
updated converge-ui to 1.0 version, removed unnecessary header styles,

### DIFF
--- a/aeolus-conductor.spec.in
+++ b/aeolus-conductor.spec.in
@@ -74,7 +74,7 @@ Requires: curl
 BuildRequires: rubygem(sass)
 BuildRequires: rubygem(compass) >= 0.11.5
 BuildRequires: rubygem(compass-960-plugin) >= 0.10.4
-BuildRequires: converge-ui-devel >= 1.0.2
+BuildRequires: converge-ui-devel >= 1.0.3
 
 BuildArch: noarch
 

--- a/src/app/stylesheets/_header.scss
+++ b/src/app/stylesheets/_header.scss
@@ -9,7 +9,7 @@ header#header {
 
   .logo{
     width: 223px;
-    bottom: 15px;
+    bottom: 0px;
   }
 
   .header-widget {
@@ -17,24 +17,9 @@ header#header {
   }
 
   #widget-container {
-    top:27px;
-
-  	#usermenu {
-  	list-style:none;
-  	  li {
-  		  background-color: rgba(25, 25, 30, 0.4);
-  		  border: none;
-        -webkit-border-radius: .5em;
-        -moz-border-radius: .5em;
-        border-radius: .5em;
-        color:#fff;
-  		  display:inline;
-  		  list-style:none;
-  		  margin-right:.8em;
-  		  padding:0 .8em;
-    	  &:last-child {margin-right:auto;}
-    	  a {color:#fff;text-decoration:none;}
-  	  }
-  	}
+    li.header-widget a{
+      text-decoration:none;
+      font-family: $screenfont; // $headfont (Overpass) is set for whole header, which aligns wrong in the line
+    }
   }
 }

--- a/src/app/views/layouts/application.html.haml
+++ b/src/app/views/layouts/application.html.haml
@@ -45,7 +45,7 @@
   = render_navigation :level => 1
 
 = content_for :widgets do
-  %ul#usermenu
+  %ul
     - if current_user
       %li.header-widget= link_to format_user_name(current_user), account_path
       %li.header-widget= link_to t('masthead.my_account'), account_path


### PR DESCRIPTION
updated requirement for converge-ui-devel 1.0.3 on spec.in

This patch updates conductor to work with the converge-ui converge-ui-devel-1.0.3-1, origin/CONVERGE-UI-1.0 (commit 26ce309)

This patch should go to both master and 1.1 branches.

CONVERGE-UI-1.0 is the point from which converge-ui-devel should be built (for conductor 1.1)
