### PR TITLE
Removes a malformed haml comment from layout

### DIFF
--- a/src/app/views/layouts/application.html.haml
+++ b/src/app/views/layouts/application.html.haml
@@ -36,8 +36,6 @@
   = javascript_include_tag "converge-ui/vendor/jquery/plugins/flot-0.7/jquery.flot.js"
   = javascript_include_tag "converge-ui/vendor/jquery/plugins/flot-0.7/excanvas.js"
 
-/= content_for :javascripts_block do
-
 = content_for :logo do
   = link_to t('layout.appname'), root_path, :class => "logo"
 


### PR DESCRIPTION
This was displaying the haml as an HTML comment, which was
kind of silly. Since it wasn't used, I'm just removing it.
