### PR TITLE
BZ857491, added unauthenticated.js.erb to spec.in, fixed login screen wa...

### DIFF
--- a/aeolus-conductor.spec.in
+++ b/aeolus-conductor.spec.in
@@ -226,6 +226,7 @@ haml="app/views/hardware_profiles app/views/realm_mappings \
       app/views/api/target_images app/views/api/entrypoint \
       app/views/api/environments \
       vendor/provider_selection/views/penalty_for_failure"
+erb="app/views/user_sessions"
 mustache="app/views/instances app/views/pools app/views/deployments \
           app/views/deployables app/views/images"
 html="public"
@@ -262,7 +263,7 @@ yml="config config/locales config/locales/defaults config/locales/overrides
      config/locales/overrides/role_definitions config/locales/activerecord \
      config/locales/strategies"
 xml="app/util"
-for filetype in builder css eot feature gif haml mustache html ico jpg js json key opts png \
+for filetype in builder css eot feature gif haml erb mustache html ico jpg js json key opts png \
     rake rb rhtml scss svg ttf txt woff yml xml; do
     dirs=${!filetype}
 

--- a/src/app/stylesheets/login.scss
+++ b/src/app/stylesheets/login.scss
@@ -33,7 +33,7 @@ article{
           position: absolute;
           left: 4px;
           top: 0px;
-          background: url("/images/flash_warning_icon.png") no-repeat 0 0;
+          background: image-url("flash_warning_icon.png") no-repeat 0 0;
         }
       }
     }


### PR DESCRIPTION
...rning icon

This patch fixes BZ857491 (https://bugzilla.redhat.com/show_bug.cgi?id=857491), it makes sure that unauthenticated.js.erb makes it into rpm and it fixes the warning icon reference in the login stylesheet.

Please do proper end-to-end testing.

This patch should be cherry-picked to 1.1 upon ACK.
