### PR TITLE
BZ#857427 - Wrong status displayed for "conductor-delayed_job" service on rhel

### DIFF
--- a/conf/conductor-delayed_job
+++ b/conf/conductor-delayed_job
@@ -19,14 +19,14 @@ DJOB_PIDDIR="${DJOB_PIDDIR:-/var/run/aeolus-conductor/}"
 
 DJOB_PATH=$CONDUCTOR_DIR/script/
 DJOB_PROG=delayed_job
-DJOB_PIDFILE=$DJOB_PIDDIR/$DJOB_PROG.pid
+DJOB_DAEMON_COUNT=2
 
 . /etc/init.d/functions
 
 start() {
     echo -n "Starting conductor-delayed_job: "
 
-    daemon --user=$AEOLUS_USER $DJOB_PATH/$DJOB_PROG start -n 2 --pid-dir=$DJOB_PIDDIR
+    daemon --user=$AEOLUS_USER $DJOB_PATH/$DJOB_PROG start -n $DJOB_DAEMON_COUNT --pid-dir=$DJOB_PIDDIR
     RETVAL=$?
     if [ $RETVAL -eq 0 ] && touch $DJOB_LOCKFILE ; then
       echo_success
@@ -62,8 +62,11 @@ case "$1" in
       start
       ;;
     status)
-     status -p $DJOB_PIDFILE $DJOB_PROG
-     RETVAL=$?
+     RETVAL=0
+     for i in $(seq 0 $(($DJOB_DAEMON_COUNT - 1))); do
+         status -p $DJOB_PIDDIR/$DJOB_PROG.$i.pid $DJOB_PROG.$i
+         RETVAL=$(($? | $RETVAL))
+     done
      ;;
     force-reload)
       restart


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=857427

The delayed_job init script starts two daemons, each with their own
pid file.  The status option of the init script needs to verify the
status of each daemon.  Previously it was assuming only one daemon and
was looking for the wrong pidfile altogether.
