### PR TITLE
BZ857500 Removed overriding body background declaration

### DIFF
--- a/src/app/stylesheets/_header.scss
+++ b/src/app/stylesheets/_header.scss
@@ -7,6 +7,10 @@
 header#header {
   height:60px;
 
+  &:after{
+    display: none; // reset :after declaration coming from converge-ui header
+  }
+
   .logo{
     width: 223px;
     bottom: 0px;

--- a/src/app/stylesheets/layout.scss
+++ b/src/app/stylesheets/layout.scss
@@ -24,7 +24,6 @@ $width: 960px;
 /* body */
 
 body{
-  @include background-image(linear-gradient(#ebebeb, #d9d9d9));
   font-family: $font-family-base;
   font-size: 12px; /* 12px base */
   color: #333;


### PR DESCRIPTION
This patch also hides the #header:after block which is redundant

https://bugzilla.redhat.com/show_bug.cgi?id=857500
