### PR TITLE
BZ 858030 - Allow 0 storage in HWPs

### DIFF
--- a/src/app/models/hardware_profile_property.rb
+++ b/src/app/models/hardware_profile_property.rb
@@ -63,7 +63,10 @@ class HardwareProfileProperty < ActiveRecord::Base
 
   validates_presence_of :unit
   validates_numericality_of :value, :greater_than => 0,
-                :if => Proc.new{|p| (p.name == MEMORY or p.name == STORAGE or p.name == CPU) and p.value.present?}
+                :if => Proc.new{|p| (p.name == MEMORY or p.name == CPU) and p.value.present?}
+
+  validates_numericality_of :value, :greater_than_or_equal_to => 0,
+                :if => Proc.new{|p| p.name == STORAGE and p.value.present?}
 
   validates_numericality_of :range_first, :greater_than => 0,
                 :if => Proc.new{|p| (p.name == MEMORY or p.name == STORAGE or p.name == CPU) and


### PR DESCRIPTION
A hardware profile with no storage is a valid configuration,
so Conductor should accept it.

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=858030
