### PR TITLE
RM 3850 - show, add, and remove provider accounts within a pool family

### DIFF
--- a/src/app/controllers/pool_families_controller.rb
+++ b/src/app/controllers/pool_families_controller.rb
@@ -149,7 +149,10 @@ class PoolFamiliesController < ApplicationController
 
     if ProviderAccount.count == 0
       flash[:error] = t('pool_families.flash.error.no_provider_accounts')
-      redirect_to pool_family_path(@pool_family, :details_tab => 'provider_accounts') and return
+      respond_to do |format|
+        format.html { redirect_to pool_family_path(@pool_family, :details_tab => 'provider_accounts') and return }
+        format.xml { raise(Aeolus::Conductor::API::Error.new(500, flash[:error])) }
+      end
     end
 
     @provider_accounts = ProviderAccount.
@@ -163,6 +166,10 @@ class PoolFamiliesController < ApplicationController
 
     if params[:accounts_selected].blank?
       flash[:error] = t"pool_families.flash.error.select_to_add_accounts" if request.post?
+      respond_to do |format|
+        format.html
+        format.xml { raise(Aeolus::Conductor::API::Error.new(500, flash[:error])) }
+      end
     else
       ProviderAccount.find(params[:accounts_selected]).each do |provider_account|
         if check_privilege(Privilege::USE, provider_account) and
@@ -182,6 +189,13 @@ class PoolFamiliesController < ApplicationController
       respond_to do |format|
         format.html { redirect_to pool_family_path(@pool_family, :details_tab => 'provider_accounts') }
         format.js { render :partial => 'provider_accounts' }
+        format.xml {
+          if flash[:error]
+            raise(Aeolus::Conductor::API::Error.new(500, flash[:error]))
+          else
+            render :show, :locals => { :pool_family => @pool_family }
+          end
+        }
       end
     end
   end
@@ -194,6 +208,10 @@ class PoolFamiliesController < ApplicationController
 
     if params[:accounts_selected].blank?
       flash[:error] = t"pool_families.flash.error.select_to_remove_accounts"
+      respond_to do |format|
+        format.html
+        format.xml { raise(Aeolus::Conductor::API::Error.new(500, flash[:error])) }
+      end
     else
       ProviderAccount.find(params[:accounts_selected]).each do |provider_account|
         if @pool_family.provider_accounts.delete provider_account
@@ -212,6 +230,13 @@ class PoolFamiliesController < ApplicationController
     respond_to do |format|
       format.html { redirect_to pool_family_path(@pool_family, :details_tab => 'provider_accounts') }
         format.js { render :partial => 'provider_accounts' }
+      format.xml {
+        if flash[:error]
+          raise(Aeolus::Conductor::API::Error.new(500, flash[:error]))
+        else
+          render :show, :locals => { :pool_family => @pool_family }
+        end
+      }
     end
   end
 

--- a/src/app/views/pool_families/_detail.xml.haml
+++ b/src/app/views/pool_families/_detail.xml.haml
@@ -8,3 +8,6 @@
   %pools
     - pool_family.pools.each do |pool|
       %pool{:id => pool.id, :href => api_pool_url(pool.id)}
+  %provider_accounts
+    - pool_family.provider_accounts.each do |pa|
+      %provider_account{:id => pa.id, :href => api_provider_account_url(pa.id)}

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -298,7 +298,13 @@ Conductor::Application.routes.draw do
     resources :provider_types, :only => [:index, :show]
     resources :hardware_profiles, :only => [:index, :show, :destroy, :create]
     resources :pools, :only => [:index, :show, :create, :update, :destroy]
-    resources :pool_families, :only => [:index, :show, :create, :update, :destroy]
+    resources :pool_families, :only => [:index, :show, :create, :update, :destroy] do
+      member do
+        post 'add_provider_accounts'
+        post 'remove_provider_accounts'
+      end
+    end
+
   end
 
   #match 'matching_profiles', :to => '/hardware_profiles/matching_profiles/:hardware_profile_id/provider/:provider_id', :controller => 'hardware_profiles', :action => 'matching_profiles', :conditions => { :method => :get }, :as =>'matching_profiles'


### PR DESCRIPTION
https://www.aeolusproject.org/redmine/issues/3850

API docs updated at https://www.aeolusproject.org/redmine/projects/aeolus/wiki/Pool_Families

I am curious as to people's opinion on how to do these sorts of mappings. As implemented a user passes in provider ids as a list of options in an accounts_selected array. Is there a better way of doing this?
