### PR TITLE
Return full provider API output if 'with_data' is supplied

### DIFF
--- a/src/app/controllers/providers_controller.rb
+++ b/src/app/controllers/providers_controller.rb
@@ -40,7 +40,7 @@ class ProvidersController < ApplicationController
     respond_to do |format|
       format.html
       format.js { render :partial => 'list' }
-      format.xml { render :partial => 'list.xml' , :locals => { :with_data => false }}
+      format.xml { render :partial => 'list.xml' , :locals => { :with_data => params[:with_data] }}
     end
   end
 


### PR DESCRIPTION
(BZ#859521 - errors with configure if provider already exists
https://bugzilla.redhat.com/show_bug.cgi?id=859521)

aeolus-configure needs to query the providers api when attempting to
add a new provider, in order to ensure that the provider does not
already exist.  Previously the list action would return the full
provider body, but since e738313 instead contains stub providers
containing only id and href.  aeolus-configure needs the full body (or
more specifically, the name attribute) in order to check if a named
provider already exists.

This patch allows the API user to supply 'with_data' as a parameter,
in which case the providers list action will return the full body for
each provider.
