### PR TITLE
BZ859926 Deployments preset filters translation fix

### DIFF
--- a/src/app/views/deployments/_list.html.haml
+++ b/src/app/views/deployments/_list.html.haml
@@ -6,7 +6,7 @@
 - content_for :filter_controls do
   %li
     = label_tag :deployments_preset_filter, t('filter_table.viewing')
-    = select_tag(:deployments_preset_filter, preset_filters_options_for_select(Deployment::PRESET_FILTERS_OPTIONS, params[:deployments_preset_filter]), :include_blank => t("deployments.deployments_filters.all_deployments"))
+    = select_tag(:deployments_preset_filter, preset_filters_options_for_select(Deployment::PRESET_FILTERS_OPTIONS, params[:deployments_preset_filter]), :prompt => t("deployments.preset_filters.all_deployments"))
     = hidden_field_tag :current_path, request.fullpath
     = restful_submit_tag t("filter_table.apply_filters"), "filter", filter_deployments_path, 'POST', :class => 'button', :id => 'apply_deployments_preset_filter'
     %span.label.badge.dark= @deployments.count


### PR DESCRIPTION
This patch corrects the translation key for deployments preset filter "All deployments" option.

https://bugzilla.redhat.com/show_bug.cgi?id=859926
