### PR TITLE
Refactoring of cucumber steps for API responses

### DIFF
--- a/src/features/provider_account_api.feature
+++ b/src/features/provider_account_api.feature
@@ -37,7 +37,7 @@ Feature: Manage Provider Accounts via API
 
   Scenario: Create a new provider account with bad request
     When I create provider account with incorrect data
-    Then I should receive Bad Request message
+    Then I should receive Bad Request error
     And the provider account should not be created
 
   Scenario: Update a provider account
@@ -49,10 +49,10 @@ Feature: Manage Provider Accounts via API
   Scenario: Update a provider account with bad request
     Given there is a provider account
     When I update that provider account with incorrect data
-    Then I should receive Bad Request message
+    Then I should receive Bad Request error
     And the provider account should not be updated
 
   Scenario: Attempt to update non existing provider account
     Given the specified provider account does not exist in the system
     When I attempt to update the provider account
-    Then I should receive a Provider Account Not Found error
+    Then I should receive Not Found error

--- a/src/features/provider_api.feature
+++ b/src/features/provider_api.feature
@@ -45,7 +45,7 @@ Feature: Manage Providers via API
 
   Scenario: Create a new provider with bad request
     When I create provider with incorrect data via XML
-    Then I should receive Bad Request message
+    Then I should receive Bad Request error
     And the provider should not be created
 
   Scenario: Update a provider
@@ -57,7 +57,7 @@ Feature: Manage Providers via API
   Scenario: Update a provider with bad request
     Given there is a provider
     When I update that provider with incorrect data via XML
-    Then I should receive Bad Request message
+    Then I should receive Bad Request error
     And the provider should not be updated
 
     #  Scenario: Attempt to update non existing provider
@@ -69,11 +69,11 @@ Feature: Manage Providers via API
   Scenario: Delete Provider
     Given there is a provider
     When I delete that provider via XML
-    Then I should received an OK message
+    Then I should receive an OK message
     And the provider should be deleted
 
   Scenario: Attempt to delete non-existant provider
     Given the specified provider does not exist in the system
     When I attempt to delete the provider
-    Then I should receive a Provider Not Found error
+    Then I should receive Not Found error
     And no provider should be deleted

--- a/src/features/step_definitions/api_steps.rb
+++ b/src/features/step_definitions/api_steps.rb
@@ -13,6 +13,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+
+Given /^I use my authentication credentials in each request$/ do
+  authorize(@user.username, 'secret')
+end
+
 Then /^I should see xml element "([^"]*)"$/ do |element|
   Then %{I should see "#{element}"}
 end
@@ -73,6 +78,33 @@ Then /^this path should contain the following elements:$/ do |table|
     rescue Exception => e
     end
   end
+end
+
+Then /^I should receive(?: an?)? (.+) message$/ do |status_name|
+  status_codes = {
+    'OK' => 200,
+    'Created' => 201,
+  }
+
+  response = last_response
+  response.headers['Content-Type'].should include('application/xml')
+  response.status.should be_eql(status_codes[status_name])
+end
+
+Then /^I should receive(?: an?)? (.+) error$/ do |status_name|
+  status_codes = {
+    'Bad Request' => 400,
+    'Not Found' => 404,
+  }
+
+  response = last_response
+  response.headers['Content-Type'].should include('application/xml')
+  response.status.should be_eql(status_codes[status_name])
+  xml_body = Nokogiri::XML(response.body)
+  # FIXME the XPath expectation should be more restrictive once we standardize the API
+  # As of 2012-09-24, some actions return <errors> with multiple <error> inside
+  # and others return just <error>
+  xml_body.xpath('//error').size.should >= 1
 end
 
 def send_xml_get(uri)

--- a/src/features/step_definitions/provider_api_steps.rb
+++ b/src/features/step_definitions/provider_api_steps.rb
@@ -1,10 +1,5 @@
 World(Rack::Test::Methods)
 
-# TODO: move to some common file for API
-Given /^I use my authentication credentials in each request$/ do
-  authorize(@user.username, 'secret')
-end
-
 When /^I request a list of providers returned as XML$/ do
   header 'Accept', 'application/xml'
   get api_providers_path
@@ -55,12 +50,6 @@ When /^I create provider with correct data via XML$/ do
   post api_providers_path, xml_provider
 end
 
-Then /^I should received?(?: an)? OK message$/ do
-  response = last_response
-  response.headers['Content-Type'].should include('application/xml')
-  response.status.should be_eql(200)
-end
-
 When /^I create provider with incorrect data via XML$/ do
   header 'Accept', 'application/xml'
   header 'Content-Type', 'application/xml'
@@ -78,12 +67,6 @@ When /^I create provider with incorrect data via XML$/ do
   post api_providers_path, xml_provider
 end
 
-Then /^I should receive Bad Request message$/ do
-  response = last_response
-  response.headers['Content-Type'].should include('application/xml')
-  response.status.should be_eql(400)
-end
-
 When /^I delete that provider via XML$/ do
   header 'Accept', 'application/xml'
 
@@ -94,14 +77,6 @@ When /^I attempt to delete the provider$/ do
   header 'Accept', 'application/xml'
 
   delete api_provider_path(@provider)
-end
-
-Then /^I should received?(?: a)?(?: .+)? Not Found error$/ do
-  response = last_response
-  response.headers['Content-Type'].should include('application/xml')
-  response.status.should be_eql(404)
-  xml_body = Nokogiri::XML(response.body)
-  xml_body.xpath('//error').size.should be_eql(1)
 end
 
 When /^I update that provider with correct data via XML$/ do


### PR DESCRIPTION
Steps that could be used commonly in all cucumber features for API are
moved from provider_api_steps.rb to api_steps.rb.

There were some similar steps like:
'should receive OK message',
'should receive Bad Request error',
'should receive Not Found error'.

This commit makes these steps more DRY. There are just two steps now,
one for general messages (which checks just status code and content
type) and one for errors (which checks status code, content type and
presence of error message in the response body).

Scenarios affected by the step changes are updated accordingly.

Some scenarios included steps like 'should receive Provider Not Found
error'. After this commit, only 'should receive Not Found error' variant
is used to prevent misguiding the reader. ('Should receive Provider Not
Found error' looked like it performed some expectations related
specifically to Provider, but in fact it didn't perform any such
expectations. It performed just the same expectations as 'should receive
Not Found error'.)
