### PR TITLE
BZ860751 - %postun scriptlet fails for aeolus-conductor-daemons

### DIFF
--- a/aeolus-conductor.spec.in
+++ b/aeolus-conductor.spec.in
@@ -428,13 +428,17 @@ if [ $1 = 0 ]; then
 fi
 
 %postun daemons
-#%if %{systemd}
+%if %{systemd}
 /bin/systemctl daemon-reload >/dev/null 2>&1 || :
+%endif
 if [ $1 -ge 1 ] ; then
     # Package upgrade, not uninstall
+    %if %{systemd}
     /bin/systemctl try-restart conductor-delayed_job.service >/dev/null 2>&1
+    %else
+    /sbin/service conductor-delayed_job condrestart > /dev/null 2>&1
+    %endif
 fi
-#%endif
 
 
 %files

--- a/conf/conductor-delayed_job
+++ b/conf/conductor-delayed_job
@@ -50,6 +50,19 @@ stop() {
     fi
 }
 
+rh_status() {
+    DEAD=0
+    for i in $(seq 0 $(($DJOB_DAEMON_COUNT - 1))); do
+        status -p $DJOB_PIDDIR/$DJOB_PROG.$i.pid $DJOB_PROG.$i
+        DEAD=$(($? | $DEAD))
+    done
+    return $DEAD
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
 case "$1" in
     start)
       start
@@ -62,12 +75,12 @@ case "$1" in
       start
       ;;
     status)
-     RETVAL=0
-     for i in $(seq 0 $(($DJOB_DAEMON_COUNT - 1))); do
-         status -p $DJOB_PIDDIR/$DJOB_PROG.$i.pid $DJOB_PROG.$i
-         RETVAL=$(($? | $RETVAL))
-     done
-     ;;
+      rh_status
+      ;;
+    condrestart|try-restart)
+      rh_status_q || exit 0
+      restart
+      ;;
     force-reload)
       restart
       ;;


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=860751

This implements the condrestart action for the delayed_job sysvinit
script.  The %postun scriptlet for the daemon subpackage is updated to
use the condrestart action on non-systemd systems.

For more info, see:
https://fedoraproject.org/wiki/Packaging:SysVInitScript?rd=Packaging/SysVInitScript#condrestart_and_try-restart
