### PR TITLE
Don't erase %{app_root} during %pre

### DIFF
--- a/aeolus-conductor.spec.in
+++ b/aeolus-conductor.spec.in
@@ -172,8 +172,6 @@ getent passwd aeolus >/dev/null || \
 # Previously ~aeolus was set to /var/aeolus
 # If this is an upgrade scenario, fix the home directory
 test ~aeolus == /usr/share/aeolus-conductor || usermod --home /usr/share/aeolus-conductor aeolus
-#remove any possible remains after uninstalation from app_root
-%{__rm} -rf %{app_root}/*
 
 %install
 %{__mkdir} -p %{buildroot}


### PR DESCRIPTION
Here's roughly what is happening here
- RPM is asked to update aeolus-conductor
- As part of the transaction, RPM checks the status of settings.yml.
  RPM finds that (1) settings.yml is marked as %config in the spec
  file, (2) settings.yml as shipped with $new_version contains the
  same content as shipped with $old_version (it ignores the contents
  of the file as it exists on the filesystem), and (3) settings.yml
  has local modifications (via aeolus-configure).
- Because of 1-3 above, RPM marks settings.yml to be skipped during
  the transaction.
- The %pre scriptlet runs, and removes %{app_root}, which in turn
  removes settings.yml.
- Because the transaction has already decided to skip settings.yml, no
  action is taken on it.  At this point, the file is gone.  RPM will
  not lay down the file as it exists in the RPM, nor will it produce
  any sort of .rpmsave or .rpmnew file.

Related bug:
860822 - aeolus-conductor RPM upgrade deletes settings.yml
https://bugzilla.redhat.com/show_bug.cgi?id=860822
