### PR TITLE
Don't error if condrestart of delayed_job fails

### DIFF
--- a/aeolus-conductor.spec.in
+++ b/aeolus-conductor.spec.in
@@ -436,7 +436,7 @@ if [ $1 -ge 1 ] ; then
     %if %{systemd}
     /bin/systemctl try-restart conductor-delayed_job.service >/dev/null 2>&1
     %else
-    /sbin/service conductor-delayed_job condrestart > /dev/null 2>&1
+    /sbin/service conductor-delayed_job condrestart > /dev/null 2>&1 || :
     %endif
 fi
 


### PR DESCRIPTION
This will happen when trying to downgrade to an older version of
aeolus-conductor-daemons where the init script doesn't support the
condrestart option.  In this case, the best thing to do is to just do
nothing.
