### PR TITLE
Bumped deltacloud-client version in Gemfile.lock

### DIFF
--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
     delayed_job (2.1.4)
       activesupport (~> 3.0)
       daemons
-    deltacloud-client (0.5.0)
+    deltacloud-client (1.0.3)
       nokogiri (>= 1.4.3)
       rest-client (>= 1.6.1)
     diff-lcs (1.1.3)


### PR DESCRIPTION
0.5.0 is quite obsolete now
