### PR TITLE
BZ 861063 - Post-login redirect goes to referer for non-GET URLs

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -256,7 +256,7 @@ class ApplicationController < ActionController::Base
   end
 
   def store_location
-    session[:return_to] = request.fullpath
+    session[:return_to] = request.get? ? request.fullpath : request.referer
   end
 
   def back_or_default_url(default)


### PR DESCRIPTION
The existing redirect code to return people to their previous
URL did not consider request type, and would thus redirect you to
various URLs using a GET which was usually incorrect.

For non-GET URLs, we should instead redirect to the referring page.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=861063
