### PR TITLE
BZ 861471 - fixed saving of changed launch params in deployment

### DIFF
--- a/src/app/models/deployment.rb
+++ b/src/app/models/deployment.rb
@@ -578,6 +578,7 @@ class Deployment < ActiveRecord::Base
         end
       end
     end
+    self.deployable_xml = deployable_xml.to_s
   end
 
   def destroy_deployment_config

--- a/src/spec/models/deployment_spec.rb
+++ b/src/spec/models/deployment_spec.rb
@@ -595,6 +595,16 @@ describe Deployment do
 
   end
 
+  describe ".inject_launch_parameters" do
+    it "should update deployable_xml with changed parameters before save" do
+      d = Factory.build :deployment_with_launch_parameters
+      d.launch_parameters = { 'assembly_with_launch_parameters' => { 'service_with_launch_parameters' => { 'launch_parameter_1' => 'changedvalue1' }}}
+      d.save!
+      # d.reload
+      Deployment.find(d.id).deployable_xml.to_s.should match("changedvalue1")
+    end
+  end
+
   describe ".instances.instance_parameters" do
     it "should not have any instance parameters" do
       @deployment = Factory.build :deployment


### PR DESCRIPTION
Deployment's deployable_xml attribute was not updated properly before saving.

https://bugzilla.redhat.com/show_bug.cgi?id=861471
