### PR TITLE
Fix backwards logic in Provider.valid_framework?

### DIFF
--- a/src/app/models/provider.rb
+++ b/src/app/models/provider.rb
@@ -283,7 +283,7 @@ class Provider < ActiveRecord::Base
 
   def valid_framework?
     begin
-      connect!.nil?
+      !! connect!
     rescue Exception => e
       logger.error("Error connecting to framework: #{e.message}")
       logger.error("Backtrace: #{e.backtrace.join("\n")}")


### PR DESCRIPTION
Looks like this got reversed in 598c9e9b; it causes adding new
providers to fail.  Just return the truthiness of connect!, since it
returns the client object if successful.
