### PR TITLE
Change 'url' attributes to 'href' in APIs

### DIFF
--- a/src/app/views/pool_families/_detail.xml.haml
+++ b/src/app/views/pool_families/_detail.xml.haml
@@ -1,5 +1,5 @@
 !!! XML
-%pool_family{:id => pool_family.id, :url => api_pool_family_url(pool_family)}
+%pool_family{:id => pool_family.id, :href => api_pool_family_url(pool_family)}
   %name= pool_family.name
   -if pool_family.quota.maximum_running_instances
     %quota{ :maximum_running_instances => pool_family.quota.maximum_running_instances}

--- a/src/app/views/pools/_detail.xml.haml
+++ b/src/app/views/pools/_detail.xml.haml
@@ -1,7 +1,7 @@
 !!! XML
-%pool{:id => pool.id, :url => api_pool_url(pool)}
+%pool{:id => pool.id, :href => api_pool_url(pool)}
   %name= pool.name
-  %pool_family{:id => pool.pool_family.id, :url=> pool_family_url(pool.pool_family)}= pool.pool_family.name
+  %pool_family{:id => pool.pool_family.id, :href => pool_family_url(pool.pool_family)}= pool.pool_family.name
   -if pool.quota.maximum_running_instances
     %quota{ :maximum_running_instances => pool.quota.maximum_running_instances}
   -else

--- a/src/spec/controllers/pool_families_controller_spec.rb
+++ b/src/spec/controllers/pool_families_controller_spec.rb
@@ -87,6 +87,8 @@ describe PoolFamiliesController do
       response.should have_content_type("application/xml")
       response.body.should be_xml
       xml = Nokogiri::XML(response.body)
+      xml.xpath("/pool_family/@id").size.should == 1
+      xml.xpath("/pool_family/@href").size.should == 1
       xml.xpath("/pool_family/name").text.should == name
       xml.xpath("/pool_family/quota/@maximum_running_instances").text.should == quota
       pool_set = xml.xpath('/pool_family/pools/pool')

--- a/src/spec/controllers/pools_controller_spec.rb
+++ b/src/spec/controllers/pools_controller_spec.rb
@@ -115,8 +115,11 @@ describe PoolsController do
       response.body.should be_xml
       xml = Nokogiri::XML(response.body)
       xml.xpath("/pool/name").text.should == name
+      xml.xpath("/pool/@id").size.should == 1
+      xml.xpath("/pool/@href").size.should == 1
       xml.xpath("/pool/pool_family").text.should == familyName
       xml.xpath("/pool/pool_family/@id").text.should == "#{familyId}"
+      xml.xpath("/pool/pool_family/@href").text.should == pool_family_url(familyId)
       xml.xpath("/pool/quota/@maximum_running_instances").text.should == quota
       xml.xpath("/pool/enabled").text.should == enabled
       xml.xpath("/pool/catalogs").size.should == 1


### PR DESCRIPTION
We now use 'href' attribute everywhere to reference other API resources
in XML responses.
