### PR TITLE
Correction of using bad model in cukes step defs

### DIFF
--- a/src/features/step_definitions/deployable_steps.rb
+++ b/src/features/step_definitions/deployable_steps.rb
@@ -14,7 +14,7 @@
 #   limitations under the License.
 #
 When /^I check "([^"]*)" catalog entry$/ do |arg1|
-  dep = CatalogEntry.find_by_deployable_id(Deployable.find_by_name(arg1))
+  dep = Deployable.find_by_name(arg1)
   check("deployable_checkbox_#{dep.id}")
 end
 

--- a/src/features/support/paths.rb
+++ b/src/features/support/paths.rb
@@ -46,9 +46,8 @@ module NavigationHelpers
 
     when /^(.*)'s catalog entry page$/i
       deployable = Deployable.find_by_name($1)
-      catalog_entry = deployable.catalog_entries.first
-      catalog = catalog_entry.catalog
-      catalog_deployable_path(catalog, catalog_entry)
+      catalog = deployable.catalogs.first
+      catalog_deployable_path(catalog, deployable)
 
     when /the account page/
       account_path


### PR DESCRIPTION
This patch is solution for https://www.aeolusproject.org/redmine/issues/3888

There was bad model used for determining id in cucumber step definitions.
Model used was CatalogEntry instead of Deployable.
