### PR TITLE
Consistent error messages for API

### DIFF
--- a/src/app/views/api/validation_error.xml.haml
+++ b/src/app/views/api/validation_error.xml.haml
@@ -1,5 +1,5 @@
 !!!XML
-%errors
-  - errors.full_messages.each do |message_error|
-    %error
-      %message= message_error
+%error
+  %code ValidationError
+  -# Rails error messages don't have dots at the end, we need to append them
+  %message= errors.full_messages.map { |message| message + '.' }.join(' ')

--- a/src/features/step_definitions/api_steps.rb
+++ b/src/features/step_definitions/api_steps.rb
@@ -101,10 +101,9 @@ Then /^I should receive(?: an?)? (.+) error$/ do |status_name|
   response.headers['Content-Type'].should include('application/xml')
   response.status.should be_eql(status_codes[status_name])
   xml_body = Nokogiri::XML(response.body)
-  # FIXME the XPath expectation should be more restrictive once we standardize the API
-  # As of 2012-09-24, some actions return <errors> with multiple <error> inside
-  # and others return just <error>
-  xml_body.xpath('//error').size.should >= 1
+  xml_body.xpath('//error').size.should == 1
+  xml_body.xpath('/error/code').size.should == 1
+  xml_body.xpath('/error/message').text.length.should > 0
 end
 
 def send_xml_get(uri)

--- a/src/spec/controllers/pools_controller_spec.rb
+++ b/src/spec/controllers/pools_controller_spec.rb
@@ -158,7 +158,8 @@ describe PoolsController do
         response.should have_content_type("application/xml")
         response.body.should be_xml
         xml = Nokogiri::XML(response.body)
-        xml.xpath("/errors/error/message").text.should == "Pool family can't be blank"
+        xml.xpath("/error/code").text.should == "ValidationError"
+        xml.xpath("/error/message").text.length.should > 0
       end
 
     end
@@ -257,7 +258,8 @@ describe PoolsController do
         response.should have_content_type("application/xml")
         response.body.should be_xml
         xml = Nokogiri::XML(response.body)
-        xml.xpath("/errors/error/message").text.should == "Name can't be blank"
+        xml.xpath("/error/code").text.should == "ValidationError"
+        xml.xpath("/error/message").text.length.should > 0
       end
     end
 

--- a/src/spec/controllers/providers_controller_spec.rb
+++ b/src/spec/controllers/providers_controller_spec.rb
@@ -241,9 +241,9 @@ describe ProvidersController do
 
             context "XML body" do
               subject { Nokogiri::XML(response.body) }
-              it "should have some errors" do
-                subject.xpath('//errors').size.should be_eql(1)
-                subject.xpath('//errors/error').size.should >= 1
+              it "should return validation error" do
+                subject.xpath('/error/code').text.should == "ValidationError"
+                subject.xpath('/error/message').text.length.should > 0
               end
             end
           end

--- a/src/spec/requests/api/provider_accounts_spec.rb
+++ b/src/spec/requests/api/provider_accounts_spec.rb
@@ -99,9 +99,9 @@ describe "ProviderAccounts" do
         it_behaves_like "responding with XML"
         context "XML body" do
           subject { Nokogiri::XML(response.body) }
-          it "should have some errors" do
-            subject.xpath('//errors').size.should be_eql(1)
-            subject.xpath('//errors/error').size.should <= 1
+          it "should return validation error" do
+            subject.xpath('/error/code').text.should == "ValidationError"
+            subject.xpath('/error/message').text.length.should > 0
           end
         end
 
@@ -127,9 +127,9 @@ describe "ProviderAccounts" do
         it_behaves_like "responding with XML"
         context "XML body" do
           subject { Nokogiri::XML(response.body) }
-          it "should have some errors" do
-            subject.xpath('//errors').size.should be_eql(1)
-            subject.xpath('//errors/error').size.should <= 1
+          it "should return validation error" do
+            subject.xpath('/error/code').text.should == "ValidationError"
+            subject.xpath('/error/message').text.length.should > 0
           end
         end
       end
@@ -224,9 +224,9 @@ describe "ProviderAccounts" do
           it_behaves_like "responding with XML"
           context "XML body" do
             subject { Nokogiri::XML(response.body) }
-            it "should have some errors" do
-              subject.xpath('//errors').size.should be_eql(1)
-              subject.xpath('//errors/error').size.should <= 1
+            it "should return validation error" do
+              subject.xpath('/error/code').text.should == "ValidationError"
+              subject.xpath('/error/message').text.length.should > 0
             end
           end
 
@@ -254,9 +254,9 @@ describe "ProviderAccounts" do
           it_behaves_like "responding with XML"
           context "XML body" do
             subject { Nokogiri::XML(response.body) }
-            it "should have some errors" do
-              subject.xpath('//errors').size.should be_eql(1)
-              subject.xpath('//errors/error').size.should <= 1
+            it "should return validation error" do
+              subject.xpath('/error/code').text.should == "ValidationError"
+              subject.xpath('/error/message').text.length.should > 0
             end
           end
         end


### PR DESCRIPTION
**_Please ping me on IRC before merging.**_

Validation errors follow the structure of other API errors. E.g.:

```
<error>
  <code>ValidationError</code>
  <message>Pool can't be blank. Name can't be blank.</message>
</error>
```

Code for some specs and cucumber steps is updated accordingly.
