### PR TITLE
Introduces with_deleted method on paranoid objects

### DIFF
--- a/src/config/initializers/paranoia.rb
+++ b/src/config/initializers/paranoia.rb
@@ -1,0 +1,5 @@
+module Paranoia::Query
+    def with_deleted
+      unscoped
+    end
+end


### PR DESCRIPTION
It is functionally equivalent to calling "unscoped" (indeed, that's
all the method does), but it makes code using it far easier to
understand.
