### PR TITLE
BZ 863383 - fixed migration of event description

### DIFF
--- a/src/db/migrate/20120905133246_event_description_to_text.rb
+++ b/src/db/migrate/20120905133246_event_description_to_text.rb
@@ -1,9 +1,9 @@
 class EventDescriptionToText < ActiveRecord::Migration
-  def up
+  def self.up
     self.change_column :events, :description, :text
   end
 
-  def down
+  def self.down
     self.change_column :events, :description, :string
   end
 end


### PR DESCRIPTION
rails 3.2 migration uses "def up" instead of "def self.up" which was used in older rails versions.
The problem is that "def up" is silently ignored in rails 3.0.x. Because of this
event an exception was raised when handling launch fail and an instance stayed in 'new' state.

https://bugzilla.redhat.com/show_bug.cgi?id=863383
