### PR TITLE
BZ864527 - aeolus-conductor should install converge-ui into a clean dire...

### DIFF
--- a/aeolus-conductor.spec.in
+++ b/aeolus-conductor.spec.in
@@ -161,7 +161,8 @@ run aeolus-configure to configure everything.
 %build
 
 #copy converge-ui from converge-ui-devel
-cp -R /usr/share/converge-ui-devel/* ./src/vendor/converge-ui
+%{__rm} -rf ./src/vendor/converge-ui
+%{__cp} -R /usr/share/converge-ui-devel ./src/vendor/converge-ui
 
 %pre
 getent group aeolus >/dev/null || /usr/sbin/groupadd -g 180 -r aeolus 2>/dev/null || :


### PR DESCRIPTION
...ctory

https://bugzilla.redhat.com/show_bug.cgi?id=864527

If the converge-ui git submodule has been checked out, then the spec
will copy the contents of converge-ui-devel overtop of it.  However
there are some files in the submodule that are not included in the
converge-ui-devel rpm, and those files remain.  Now, we'll clean out
the converge-ui directory as shipped in the source tarball before
copying over the contents of converge-ui-devel.
