### PR TITLE
Remove converge-ui contents in dist stage of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ dist:
 	mkdir -p dist/aeolus-conductor-$(VERSION)
 	cp -a aeolus-conductor.spec AUTHORS conf COPYING Makefile src \
 		dist/aeolus-conductor-$(VERSION)
-	rm -f dist/aeolus-conductor-$(VERSION)/src/vendor/converge-ui/converge-ui-devel.spec
+	find dist/aeolus-conductor-$(VERSION)/src/vendor/converge-ui/ -mindepth 1 -maxdepth 1 | xargs rm -rf
 	tar -C dist -zcvf aeolus-conductor-$(VERSION).tar.gz aeolus-conductor-$(VERSION)
 
 


### PR DESCRIPTION
This prevents inclusion of a local checkout of the converge-ui
submodule in any rpms/srpms created using 'make rpms'. Those files
needed by the BuildRequires on converge-ui-devel should only be
pulled in during the package build. This also prevents unneeded
files (like .git subdirectories and the rel-eng/tito subdir) from
being included in addition to what's provided by converge-ui-devel.
