### PR TITLE
Removed Catalog column from Pools tables

### DIFF
--- a/src/app/controllers/pool_families_controller.rb
+++ b/src/app/controllers/pool_families_controller.rb
@@ -253,7 +253,6 @@ class PoolFamiliesController < ApplicationController
         {:name => t("pool_families.index.quota_used"), :class => 'center', :sortable => false},
         {:name => t("pool_families.index.active_instances"), :class => 'center', :sortable => false},
         {:name => t("pool_families.index.available_instances"), :class => 'center', :sortable => false},
-        {:name => t("pool_families.index.catalog"), :sortable => false},
         {:name => '', :sortable => false}
       ]
     when @view == 'images'

--- a/src/app/stylesheets/layout.scss
+++ b/src/app/stylesheets/layout.scss
@@ -2224,6 +2224,20 @@ table.pool_families{
     .caption_content{padding: 8px;}
   }
 
+  td,
+  th {
+    text-align: center;
+
+    &:first-child {
+      width: 100%;
+      text-align: left;
+    }
+
+    &:last-child {
+      text-align: right;
+    }
+  }
+
   th{
     background: rgb(225, 225, 225);
     padding: 2px 8px;

--- a/src/app/views/pool_families/_list.html.haml
+++ b/src/app/views/pool_families/_list.html.haml
@@ -32,7 +32,6 @@
           %th= t("pool_families.index.active_instances")
           %th= t("pool_families.index.available_instances")
           %th= t("pool_families.index.enabled")
-          %th= t("pool_families.index.catalog")
           %th
           %th
         - pool_family.pools.each do |pool|
@@ -48,7 +47,6 @@
             %td= pool_stats[:used_quota]
             %td= pool_stats[:available_quota].nil? ? raw('&infin;') : pool_stats[:available_quota]
             %td= pool.enabled? ? t("pool_families.index.answer_yes") : t("pool_families.index.answer_no")
-            %td= link_to pool.catalogs.first.name, catalog_path(pool.catalogs.first) if pool.catalogs.any?
             %td
               - if check_privilege(Privilege::MODIFY, pool)
                 = link_to t(:edit), edit_pool_path(pool), :class => 'button'
@@ -63,7 +61,6 @@
           %td= family_stats[:quota_percent]
           %td= family_stats[:used_quota]
           %td= family_stats[:available_quota].nil? ? raw('&infin;') : family_stats[:available_quota]
-          %td
           %td
           %td
           %td

--- a/src/app/views/pool_families/_pools.html.haml
+++ b/src/app/views/pool_families/_pools.html.haml
@@ -9,5 +9,4 @@
     %td{:class => 'center'}= pool_stats[:quota_percent]
     %td{:class => 'center'}= pool_stats[:used_quota]
     %td{:class => 'center'}= pool_stats[:available_quota].nil? ? raw('&infin;') : pool_stats[:available_quota]
-    %td= link_to pool.catalogs.first.name, catalog_path(pool.catalogs.first) if pool.catalogs.any?
     %td= link_to t(:edit), edit_pool_path(pool)

--- a/src/config/locales/en.yml
+++ b/src/config/locales/en.yml
@@ -816,7 +816,6 @@ en:
       enabled: Enabled
       answer_yes: "Yes"
       answer_no: "No"
-      catalog: "Catalog"
       total_statistics: Total
       provider_selection: 'Provider Selection'
     new:


### PR DESCRIPTION
It's useless to have Catalog link in pool row, since any Pool can have multiple
Catalogs which are not displayed.

Increased spacing for Pool name in Environment's table.
