### PR TITLE
RM 3850 - show, add, and remove provider accounts within a pool family

### DIFF
--- a/aeolus-conductor.spec.in
+++ b/aeolus-conductor.spec.in
@@ -208,6 +208,7 @@ haml="app/views/hardware_profiles app/views/realm_mappings \
       app/views/provider_selections app/views/provider_priority_groups \
       app/views/roles app/views/providers app/views/settings \
       app/views/realms app/views/pool_families app/views/layouts\
+      app/views/pool_families_to_provider_accounts_associations\
       app/views/quotas app/views/permissions \
       app/views/deployments app/views/pools \
       app/views/instances app/views/user_sessions \

--- a/src/app/controllers/pool_families_to_provider_accounts_associations_controller.rb
+++ b/src/app/controllers/pool_families_to_provider_accounts_associations_controller.rb
@@ -1,0 +1,80 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+class PoolFamiliesToProviderAccountsAssociationsController < ApplicationController
+  before_filter :require_user
+
+  def index
+    @pool_family = PoolFamily.find(params[:pool_family_id])
+    require_privilege(Privilege::VIEW, @pool_family)
+    respond_to do |format|
+      format.xml do
+        render :partial => 'list.xml'
+      end
+    end
+  end
+
+  def show
+    pool_family = PoolFamily.find(params[:pool_family_id])
+    require_privilege(Privilege::VIEW, pool_family)
+    provider_account = ProviderAccount.find(params[:id])
+    respond_to do |format|
+      if pool_family.provider_accounts.where(:id => provider_account.id).size == 1
+        format.xml { render :nothing => true, :status => :no_content }
+      else
+        format.xml { render :nothing => true, :status => :not_found }
+      end
+    end
+  end
+
+  def update
+    @pool_family = PoolFamily.find(params[:pool_family_id])
+    require_privilege(Privilege::MODIFY, @pool_family)
+
+    provider_account = ProviderAccount.find(params[:id])
+    require_privilege(Privilege::USE, provider_account)
+
+    respond_to do |format|
+      if @pool_family.provider_accounts.include?(provider_account) ||
+          (!@pool_family.provider_accounts.include?(provider_account) &&
+          @pool_family.provider_accounts << provider_account)
+        format.xml { render :nothing => true, :status => :no_content }
+      else
+        format.xml { render :template => 'api/validation_error',
+          :status => :bad_request,
+          :locals => { :errors => @pool_family.errors }}
+      end
+    end
+  end
+
+  def destroy
+    @pool_family = PoolFamily.find(params[:pool_family_id])
+    require_privilege(Privilege::MODIFY, @pool_family)
+
+    provider_account = ProviderAccount.find(params[:id])
+
+    respond_to do |format|
+      if @pool_family.provider_accounts.delete provider_account
+        format.xml { render :nothing => true, :status => :no_content }
+      else
+        format.xml { render :template => 'api/validation_error',
+          :status => :bad_request,
+          :locals => { :errors => @pool_family.errors }}
+      end
+    end
+  end
+
+end

--- a/src/app/views/pool_families/_detail.xml.haml
+++ b/src/app/views/pool_families/_detail.xml.haml
@@ -8,3 +8,6 @@
   %pools
     - pool_family.pools.each do |pool|
       %pool{:id => pool.id, :href => api_pool_url(pool.id)}
+  %provider_accounts
+    - pool_family.provider_accounts.each do |pa|
+      %provider_account{:id => pa.id, :href => api_provider_account_url(pa.id)}

--- a/src/app/views/pool_families_to_provider_accounts_associations/_list.xml.haml
+++ b/src/app/views/pool_families_to_provider_accounts_associations/_list.xml.haml
@@ -1,0 +1,4 @@
+!!! XML
+%provider_accounts
+  - @pool_family.provider_accounts.each do |acc|
+    %provider_account{:id => acc.id, :href => api_provider_account_url(acc)}

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -298,7 +298,9 @@ Conductor::Application.routes.draw do
     resources :provider_types, :only => [:index, :show]
     resources :hardware_profiles, :only => [:index, :show, :destroy, :create]
     resources :pools, :only => [:index, :show, :create, :update, :destroy]
-    resources :pool_families, :only => [:index, :show, :create, :update, :destroy]
+    resources :pool_families, :only => [:index, :show, :create, :update, :destroy] do
+      resources :provider_accounts, :controller => "pool_families_to_provider_accounts_associations", :only => [:index, :show, :update, :destroy]
+    end
     resources :catalogs, :only => [:index, :show, :create, :update, :destroy]
   end
 

--- a/src/spec/controllers/pool_families_controller_spec.rb
+++ b/src/spec/controllers/pool_families_controller_spec.rb
@@ -143,12 +143,17 @@ describe PoolFamiliesController do
         FactoryGirl.create(:pool, :name => "pool1", :pool_family => @pool_family)
         FactoryGirl.create(:pool, :name => "pool2", :pool_family => @pool_family)
         FactoryGirl.create(:pool, :name => "pool3", :pool_family => @pool_family)
+        provider_account = FactoryGirl.create(:mock_provider_account)
+        @pool_family.provider_accounts << provider_account
 
         get :show, :id => @pool_family.id
 
         assert_pool_api_success_response(@pool_family.name,
                                          "#{@pool_family.quota.maximum_running_instances}",
                                          3)
+
+        xml = Nokogiri::XML(response.body)
+        xml.xpath("/pool_family/provider_accounts/provider_account[@id=#{provider_account.id}]/@href").text.should == api_provider_account_url(provider_account.id)
       end
 
       it "show a missing pool family" do

--- a/src/spec/controllers/pool_families_to_provider_accounts_associations_spec.rb
+++ b/src/spec/controllers/pool_families_to_provider_accounts_associations_spec.rb
@@ -1,0 +1,135 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+require 'spec_helper'
+
+describe PoolFamiliesToProviderAccountsAssociationsController do
+
+  fixtures :all
+  before(:each) do
+    @admin_permission = FactoryGirl.create :admin_permission
+    @admin = @admin_permission.user
+    @user_permission = FactoryGirl.create :pool_family_user_permission
+    @user = @user_permission.user
+  end
+
+  context "API" do
+
+    before do
+      accept_xml
+      mock_warden(@admin)
+    end
+
+    describe "#index" do
+      render_views
+      it "show list of associated provider accounts" do
+        @pool_family = FactoryGirl.create :pool_family
+        @provider_account = FactoryGirl.create :mock_provider_account
+        @provider_account2 = FactoryGirl.create :mock_provider_account
+        @pool_family.provider_accounts << @provider_account
+        @pool_family.provider_accounts << @provider_account2
+
+        post :index, :pool_family_id => @pool_family.id
+
+        response.status.should be_eql(200)
+        response.should have_content_type("application/xml")
+        response.body.should be_xml
+        xml = Nokogiri::XML(response.body)
+        xml.xpath("/provider_accounts/provider_account").size.should be_eql(2)
+        xml.xpath("/provider_accounts/provider_account[@id=#{@provider_account.id}]/@href").text.should == api_provider_account_url(@provider_account.id)
+      end
+    end
+
+    describe "#show" do
+      before do
+        @pool_family = FactoryGirl.create :pool_family
+        @provider_account = FactoryGirl.create :mock_provider_account
+        @pool_family.provider_accounts << @provider_account
+      end
+
+      it "an association that exists" do
+        post :show, :id => @provider_account.id, :pool_family_id => @pool_family.id
+        response.status.should be_eql(204)
+      end
+
+      it "an association that does not exist" do
+        post :show, :id => -1, :pool_family_id => @pool_family.id
+        response.status.should be_eql(404)
+      end
+
+    end
+
+
+    describe "#update" do
+      it "create the association" do
+        @pool_family = FactoryGirl.create :pool_family
+        @provider_account = FactoryGirl.create :mock_provider_account
+        @pool_family.provider_accounts.where(:id => @provider_account.id).should be_empty
+
+        post :update, :id => @provider_account.id, :pool_family_id => @pool_family.id
+
+        response.status.should be_eql(204)
+        @pool_family.provider_accounts.where(:id => @provider_account.id).size.should == 1
+
+        # try creating it a second time
+        post :update, :id => @provider_account.id, :pool_family_id => @pool_family.id
+
+        response.status.should be_eql(204)
+      end
+
+      it "create an association for a provider account that does not exist" do
+        @pool_family = FactoryGirl.create :pool_family
+
+        post :update, :id => -1, :pool_family_id => @pool_family.id
+
+        response.status.should be_eql(404)
+      end
+
+    end
+
+    describe "#destroy" do
+      before do
+        @pool_family = FactoryGirl.create :pool_family
+        @provider_account = FactoryGirl.create :mock_provider_account
+      end
+
+      it "remove the association" do
+        @pool_family.provider_accounts << @provider_account
+        @pool_family.provider_accounts.where(:id => @provider_account.id).size.should == 1
+
+        post :destroy, :id => @provider_account.id, :pool_family_id => @pool_family.id
+
+        response.status.should be_eql(204)
+        @pool_family.provider_accounts.where(:id => @provider_account.id).should be_empty
+
+        # removing it again should result in 204
+        post :destroy, :id => @provider_account.id, :pool_family_id => @pool_family.id
+
+        response.status.should be_eql(204)
+      end
+
+      it "remove the association that does not exist" do
+        @pool_family.provider_accounts.where(:id => @provider_account.id).size.should == 0
+
+        post :destroy, :id => -1, :pool_family_id => @pool_family.id
+
+        response.status.should be_eql(404)
+      end
+    end
+
+
+  end
+end


### PR DESCRIPTION
https://www.aeolusproject.org/redmine/issues/3850

Refactored https://github.com/aeolusproject/conductor/pull/71 to use
a provider_accounts resource under pool_families to manage the
associations.

Revised from https://github.com/aeolusproject/conductor/pull/100
