### PR TITLE
unique index to pool_families_provider_accounts

### DIFF
--- a/src/db/migrate/20121011130041_add_unique_index_to_pool_families_provider_accounts.rb
+++ b/src/db/migrate/20121011130041_add_unique_index_to_pool_families_provider_accounts.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToPoolFamiliesProviderAccounts < ActiveRecord::Migration
+  def change
+    add_index :pool_families_provider_accounts, [:provider_account_id, :pool_family_id], :unique => true, :name => 'pool_fam_prov_acc_uniq_index'
+  end
+end


### PR DESCRIPTION
add unique index to pool_families_provider_accounts to prevent model corruption as seen here: 
https://github.com/aeolusproject/conductor/pull/117
