### PR TITLE
bz864806 removes the empty admin navigation div from permissions/new page

### DIFF
--- a/src/app/views/permissions/new.html.haml
+++ b/src/app/views/permissions/new.html.haml
@@ -1,5 +1,3 @@
 - if @permission_object == BasePermissionObject.general_permission_scope
   = render :partial => 'layouts/admin_nav'
-- else
-  %nav#administer_nav
 = render :partial => 'new'


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=864806

This issue comes with the problem that permissions/new is used in both monitor and
administer sections and it is quite hard to decide whether to display the administer
nav or not. This patch removes the empty admin_nav div if no administer navigation
is rendered.

In the future we are combining the Monitor and administer sections together, so the
issue will not be relevant any more.
