### PR TITLE
Fixed order of buttons in Add Config Server form

### DIFF
--- a/src/app/views/config_servers/_config_server_form.haml
+++ b/src/app/views/config_servers/_config_server_form.haml
@@ -16,5 +16,5 @@
       = password_field_tag "config_server[secret]", @config_server.secret
 
 %fieldset.options
+  = submit_tag t(:save), :name => "save", :class => "button primary", :id => "save_button"
   = link_to t(:cancel), provider_provider_account_path(@provider_account.provider, @provider_account), :class => "button danger"
-  = submit_tag t(:save), :name => "save", :class => "button", :id => "save_button"


### PR DESCRIPTION
Fixed one left form with wrong order of buttons.
