### PR TITLE
Fix rake dc:setup crash

### DIFF
--- a/src/lib/tasks/dc_tasks.rake
+++ b/src/lib/tasks/dc_tasks.rake
@@ -142,8 +142,15 @@ namespace :dc do
     drop_db = STDIN.gets.chomp
     unless drop_db.strip.eql?('no')
       Rake::Task[:'db:migrate:reset'].invoke
+
+      # Reload model classes so that they reflect changes of model attributes
+      # made by migrations.
+      ActionDispatch::Reloader.cleanup!
+      ActionDispatch::Reloader.prepare!
+
       Rake::Task[:'db:seed'].invoke
     end
+
     Rake::Task[:'dc:create_admin_user'].invoke
   end
 


### PR DESCRIPTION
`rake dc:setup` used to crash with:

```
undefined method `find_by_username' for #<Class:0x000000059b3ac0>
```

The issue is that User db table is defined by migration to have `login`
attribute, and this attribute is renamed to `username` by a later
migration. However, this change is not reflected in `User` class.

This commit reloads model classes after all migrations are done, which
fixes the issue.

Fixes RM3903.
