### PR TITLE
Sync Gemfile.lock with Gemfile

### DIFF
--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -203,8 +203,8 @@ PLATFORMS
 DEPENDENCIES
   aeolus-image!
   capybara
-  compass
-  compass-960-plugin
+  compass (>= 0.11.5, < 0.12)
+  compass-960-plugin (>= 0.10.4)
   cucumber
   cucumber-rails
   database_cleaner


### PR DESCRIPTION
There are version constraints for compass gem in Gemfile that should be
also in Gemfile.lock.

Right now, when I run `bundle`, Gemfile.lock gets regenerated differently than what's present in repo, which shouldn't happen.
