### PR TITLE
Password and Username recovery

### DIFF
--- a/aeolus-conductor.spec.in
+++ b/aeolus-conductor.spec.in
@@ -225,7 +225,8 @@ haml="app/views/hardware_profiles app/views/realm_mappings \
       app/views/pool_families_to_provider_accounts_associations\
       app/views/quotas app/views/permissions \
       app/views/deployments app/views/pools \
-      app/views/instances app/views/user_sessions \
+      app/views/instances app/views/user_sessions app/views/password_resets \
+      app/views/user_mailer
       app/views/deployables app/views/catalogs \
       app/views/provider_types app/views/api/images \
       app/views/config_servers app/views/provider_realms \
@@ -239,7 +240,7 @@ haml="app/views/hardware_profiles app/views/realm_mappings \
       app/views/api/target_images app/views/api/entrypoint \
       app/views/api/environments \
       vendor/provider_selection/views/penalty_for_failure"
-erb="app/views/user_sessions"
+erb="app/views/username_recoveries app/views/password_resets"
 mustache="app/views/instances app/views/pools app/views/deployments \
           app/views/deployables app/views/images"
 html="public"
@@ -260,7 +261,7 @@ png="public/images \
      public/stylesheets/images \
      public/stylesheets/jquery.ui-1.8.1/images"
 rake="lib/tasks"
-rb="app/models app/controllers app/controllers/api app/helpers app/services app/util \
+rb="app/models app/controllers app/controllers/api app/helpers app/mailers app/services app/util \
     config config/initializers config/environments db db/migrate \
     features/support features/step_definitions lib spec spec/controllers \
     spec/factories spec/helpers spec/models spec/services spec/controllers/api \
@@ -272,7 +273,7 @@ rb="app/models app/controllers app/controllers/api app/helpers app/services app/
 rhtml="app/views/layouts"
 svg="public/images public/images/icons"
 txt="public"
-yml="config config/locales config/locales/defaults config/locales/overrides
+yml="config config/locales config/locales/defaults config/locales/emails config/locales/overrides
      config/locales/role_definitions config/locales/classnames config/locales/will_paginate \
      config/locales/overrides/role_definitions config/locales/activerecord \
      config/locales/simple_form config/locales/strategies"

--- a/src/app/controllers/password_resets_controller.rb
+++ b/src/app/controllers/password_resets_controller.rb
@@ -1,0 +1,71 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+class PasswordResetsController < ApplicationController
+  before_filter :require_no_user
+  before_filter :find_user_by_reset_token, :only => [:edit, :update]
+  layout 'login'
+
+  def create
+    user = User.find_by_username_and_email(params[:username], params[:email])
+    user.send_password_reset if user
+    respond_to do |format|
+      # note: for security reasons we provide success message even if incorrect/non-existent email/username combination is filled in.
+      format.html{ redirect_to login_path, :notice => t("password_resets.reset_instructions_sent") }
+      format.js do
+        flash.now[:notice] = t("password_resets.reset_instructions_sent")
+      end
+    end
+  end
+
+  def edit
+    respond_to do |format|
+      if @user.password_reset_sent_at < SETTINGS_CONFIG[:action_mailer][:password_reset_token_timeout].minutes.ago
+        format.html{ redirect_to new_user_sessions_path(:password_reset => true), :alert => t("password_resets.password_reset_expired") }
+      else
+        format.html
+      end
+    end
+  end
+
+  def update
+    respond_to do |format|
+      if @user.password_reset_sent_at < SETTINGS_CONFIG[:action_mailer][:password_reset_token_timeout].minutes.ago
+        format.html{ redirect_to new_user_sessions_path(:password_reset => true), :alert => t("password_resets.password_reset_expired") }
+      end
+
+      # update the password and reset the 'password reset token' so that it cannot be reused
+      params[:user][:password_reset_token]   = nil
+      params[:user][:password_reset_sent_at] = nil
+
+      if @user.update_attributes(params[:user])
+        flash[:notice] = t("password_resets.password_reset_success")
+        format.html{ redirect_to login_path }
+        format.js { render :js => "window.location.href = '#{login_path}'" }
+      else
+        format.html{ render :edit }
+        format.js { render :edit }
+      end
+    end
+  end
+
+  def find_user_by_reset_token
+    @user = User.find_by_password_reset_token!(params[:id])
+  rescue ActiveRecord::RecordNotFound => error
+    flash[:notice] = t("password_resets.invalid_token")
+    redirect_to login_path(:card => 'password_reset')
+  end
+end

--- a/src/app/controllers/user_sessions_controller.rb
+++ b/src/app/controllers/user_sessions_controller.rb
@@ -14,35 +14,26 @@
 #   limitations under the License.
 #
 
-# Filters added to this controller apply to all controllers in the application.
-# Likewise, all the methods added will be available for all controllers.
-
 class UserSessionsController < ApplicationController
   before_filter :require_no_user, :only => [:new, :create]
   before_filter :require_user, :only => :destroy
-  layout 'converge-ui/login_layout'
+  layout 'login'
 
   def new
     @title = t('masthead.login')
-    @disable_password_recovery = true
   end
 
   def create
     authenticate!
     session[:javascript_enabled] = request.xhr?
     respond_to do |format|
-      format.html do
-        redirect_to back_or_default_url(root_url)
-      end
-      format.js do
-        render :js => "window.location.href = '#{back_or_default_url root_url}'"
-      end
+      format.html { redirect_to back_or_default_url(root_url) }
+      format.js { render :js => "window.location.href = '#{back_or_default_url root_url}'" }
     end
   end
 
   def unauthenticated
     Rails.logger.warn "Request is unauthenticated for #{request.remote_ip}"
-    @disable_password_recovery = true
 
     respond_to do |format|
       format.xml { head :unauthorized }

--- a/src/app/controllers/username_recoveries_controller.rb
+++ b/src/app/controllers/username_recoveries_controller.rb
@@ -1,0 +1,32 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+class UsernameRecoveriesController < ApplicationController
+  before_filter :require_no_user
+  layout 'login'
+
+  def create
+    users_ids = User.find_all_by_email(params[:email]).map(&:id)
+    UserMailer.delay.send_usernames(users_ids) unless users_ids.blank?
+    respond_to do |format|
+      # note: for security reasons we provide success message even if incorrect/non-existent email is filled in.
+      format.html { redirect_to login_path, :notice => t("username_recoveries.usernames_sent") }
+      format.js do
+        flash.now[:notice] = t("username_recoveries.usernames_sent")
+      end
+    end
+  end
+end

--- a/src/app/helpers/user_sessions_helper.rb
+++ b/src/app/helpers/user_sessions_helper.rb
@@ -14,20 +14,27 @@
 #   limitations under the License.
 #
 
-# Filters added to this controller apply to all controllers in the application.
-# Likewise, all the methods added will be available for all controllers.
-
 module UserSessionsHelper
   # this overrides the rails_translations and translations helpers from converge ui
   # should be removed when those two helpers are fixed in converge-ui
   @@translations = {
-    :show_password            => "user_sessions.new.show_password",
-    :example_logo             => "logo",
-    :forgot_username_password => "user_sessions.new.forgot_username_password",
-    :username                 => "user_sessions.new.username",
-    :password                 => "user_sessions.new.password",
-    :login                    => "user_sessions.new.login",
-    :recovery_link            => "Forgot %s or %s?"
+    :noscript                 => "user_sessions.noscript",
+    :username                 => "user_sessions.username",
+    :password                 => "user_sessions.password",
+    :login                    => "user_sessions.login",
+    :recovery_link            => "user_sessions.recovery_link",
+    :email_address            => "password_resets.email_address",
+    :send_login               => "username_recoveries.recover_usernames",
+    :password_unknown         => "password_resets.password_unknown",
+    :password_unknown_info    => "password_resets.password_unknown_info",
+    :reset_password           => "password_resets.reset_password",
+    :username_unknown         => "username_recoveries.username_unknown",
+    :username_unknown_info    => "username_recoveries.username_unknown_info",
+    :change_password          => "password_resets.change_password",
+    :change_password_info     => "password_resets.change_password_info",
+    :new_password             => "password_resets.new_password",
+    :confirm_password         => "password_resets.confirm_password",
+    :passwords_do_not_match   => "user_sessions.passwords_do_not_match"
   }
 
   def get_string(text_key)

--- a/src/app/mailers/user_mailer.rb
+++ b/src/app/mailers/user_mailer.rb
@@ -14,4 +14,16 @@
 #   limitations under the License.
 #
 
-SETTINGS_CONFIG = YAML.load_file("#{::Rails.root.to_s}/config/settings.yml")
+class UserMailer < ActionMailer::Base
+
+  def password_reset(user_id)
+    @user = User.find(user_id)
+    mail(:to => @user.email, :subject => t("user_mailer.password_reset.subject"))
+  end
+
+  def send_usernames(users_ids)
+    @users = User.find(users_ids)
+    @email = @users.first.email
+    mail(:to => @email, :subject => t("user_mailer.send_usernames.subject"))
+  end
+end

--- a/src/app/stylesheets/_helpers.scss
+++ b/src/app/stylesheets/_helpers.scss
@@ -5,6 +5,3 @@ HELPERS
 .clearfix { @include clearfix; }
 
 .align-center{ text-align: center; }
-
-// DO NOT DISPLAY NOSCRIPT WARNING IN CONDUCTOR
-.noscript-warning{ display: none; }

--- a/src/app/stylesheets/layout.scss
+++ b/src/app/stylesheets/layout.scss
@@ -1,6 +1,7 @@
 @import "reset";
 @import "compass/reset";
 @import "converge-ui/composites/shell";
+@import "converge-ui/composites/content_elements";
 @import "mixins";
 @import "helpers";
 @import "buttons";

--- a/src/app/stylesheets/login.scss
+++ b/src/app/stylesheets/login.scss
@@ -8,16 +8,16 @@ article{
   #notifications{
     position: relative;
 
-    div.error{
+    div.error, div.notice, div.alert{
       position: absolute;
       bottom: 15px;
       @include box-sizing(border-box);
       border: 1px solid #dddddd;
       @include border-radius(7px);
-      width: $login-container-width;
+      width: $login_container_width;
       padding: 10px;
-      @include background-image(linear-gradient(top, rgba(255, 255, 255, 0) 40%, $login_base-color 120%));
-      @include box-shadow($login_base-color 0px 12px 15px -8px);
+      @include background-image(linear-gradient(top, rgba(255, 255, 255, 0) 40%, $login_base_color 120%));
+      @include box-shadow($login_base_color 0px 12px 15px -8px);
 
       p {
         padding-left: 26px;
@@ -33,10 +33,16 @@ article{
           position: absolute;
           left: 4px;
           top: 0px;
-          background: image-url("flash_warning_icon.png") no-repeat 0 0;
+          background: image-url("converge-ui/icons/error_icon.png") no-repeat 0 0;
         }
       }
+      ul.messages li{
+        padding-left: 26px;
+        color: rgba(black, 0.48);
+      }
     }
+    div.notice p:before{ background: image-url("converge-ui/icons/success_icon.png") no-repeat 0 0; }
+    div.alert p:before{ background: image-url("converge-ui/icons/warning_icon.png") no-repeat 0 0; }
   }
 
   .container section .card{
@@ -52,12 +58,6 @@ article{
       label {
         color: rgba(black, 0.35);
         @include text-shadow(1px 1px 0 white);
-      }
-
-      input{
-        &:focus{
-          @include box-shadow(0 0 2px $login_link-color);
-        }
       }
     }
 

--- a/src/app/views/layouts/login.html.haml
+++ b/src/app/views/layouts/login.html.haml
@@ -1,0 +1,35 @@
+= content_for(:stylesheets_block) do
+  = stylesheet_link_tag '/stylesheets/compiled/login.css'
+  /[if lt IE 9]
+    = javascript_include_tag 'http://html5shiv.googlecode.com/svn/trunk/html5.js'
+    = stylesheet_link_tag '/stylesheets/login_ie8.css'
+  /[if lt IE 8]
+    = stylesheet_link_tag '/stylesheets/layout_ie7.css'
+
+= content_for(:javascripts_block) do
+  = javascript_include_tag "converge-ui/vendor/jquery/jquery-1.6.2.js"
+  = javascript_include_tag "converge-ui/vendor/rails.js"
+  = javascript_include_tag "converge-ui/login.js"
+  :javascript
+    $(document).ready(function() {
+      $("#login_form").bind("ajax:error", function(event, data, status, xhr) {
+        $("#notifications").html("<div class=\'error\'>\n <p class=\'text\'>#{t("user_sessions.flash.warning.login_failed")}<\/p>\n<\/div>\n");
+        $('form .spinner').fadeOut('fast');
+      });
+    });
+  /[if lt IE 9]
+
+= content_for :title do
+  = t("layout.appname")
+  = "| #{@title}" unless @title.blank?
+
+= content_for :notifications do
+  = render :partial => 'user_sessions/notifications'
+
+= content_for :login_logo do
+  = image_tag 'login-card-logo-upstream.png'
+
+= content_for :footer do
+  = render :partial => 'layouts/footer'
+
+= render :partial => "layouts/converge-ui/user_session_layout"

--- a/src/app/views/password_resets/create.js.erb
+++ b/src/app/views/password_resets/create.js.erb
@@ -1,0 +1,4 @@
+$('.card#password_reset').animate({ 'left' : '-360px' }, 'slow', function(){
+  $(this).css('z-index', -1);
+});
+$('#notifications').html("<%= escape_javascript render(:partial => 'user_sessions/notifications') %>");

--- a/src/app/views/password_resets/edit.html.haml
+++ b/src/app/views/password_resets/edit.html.haml
@@ -1,0 +1,8 @@
+= content_for(:content) do
+  = render :partial => "layouts/converge-ui/change_password_layout",
+           :locals => { :edit_password_reset_form_path_string => password_reset_path(params[:id]),
+                        :login_path_string => login_path }
+
+- if @user.errors.any?
+  = render 'user_sessions/error_messages', :object => @user
+

--- a/src/app/views/password_resets/edit.js.erb
+++ b/src/app/views/password_resets/edit.js.erb
@@ -1,0 +1,4 @@
+<% if @user.errors.any? %>
+  <%= render 'user_sessions/error_messages', :object => @user %>
+  $('#notifications').html("<%= escape_javascript render(:partial => 'user_sessions/notifications') %>");
+<% end %>

--- a/src/app/views/user_mailer/password_reset.text.haml
+++ b/src/app/views/user_mailer/password_reset.text.haml
@@ -1,0 +1,5 @@
+= t("user_mailer.password_reset.request_received", :username => @user.username)
+
+= edit_password_reset_url(@user.password_reset_token)
+
+= t("user_mailer.password_reset.ignore")

--- a/src/app/views/user_mailer/send_usernames.text.haml
+++ b/src/app/views/user_mailer/send_usernames.text.haml
@@ -1,0 +1,3 @@
+= t("user_mailer.send_usernames.request_received", :url => root_url, :email => @email)
+- @users.each do |user|
+  = user.username

--- a/src/app/views/user_sessions/_error_messages.html.haml
+++ b/src/app/views/user_sessions/_error_messages.html.haml
@@ -1,0 +1,6 @@
+- content_for :error_messages do
+  .error
+    %p.text= t("errors.template.header", :model => object.class.model_name.human, :count => object.errors.count)
+    %ul.messages
+      - object.errors.full_messages.each do |msg|
+        %li= msg

--- a/src/app/views/user_sessions/_notifications.html.haml
+++ b/src/app/views/user_sessions/_notifications.html.haml
@@ -1,3 +1,11 @@
 -if flash[:warning]
-  %div.error
+  .error
     %p.text= flash[:warning]
+- if flash[:notice]
+  .notice
+    %p.text= flash[:notice]
+- if flash[:alert]
+  .alert
+    %p.text= flash[:alert]
+- if content_for?(:error_messages)
+  = yield :error_messages

--- a/src/app/views/user_sessions/new.html.haml
+++ b/src/app/views/user_sessions/new.html.haml
@@ -1,33 +1,13 @@
-= content_for(:stylesheets_block) do
-  = stylesheet_link_tag '/stylesheets/compiled/login.css'
-  /[if lt IE 9]
-    = javascript_include_tag 'https://html5shiv.googlecode.com/svn/trunk/html5.js'
-    = stylesheet_link_tag '/stylesheets/login_ie8.css'
-  /[if lt IE 8]
-    = stylesheet_link_tag '/stylesheets/layout_ie7.css'
-
-= content_for(:javascripts_block) do
-  = javascript_include_tag "converge-ui/vendor/jquery/jquery-1.6.2.js"
-  = javascript_include_tag "converge-ui/vendor/rails.js"
-  = javascript_include_tag "converge-ui/login.js"
-  :javascript
-    $(document).ready(function() {
-      $("#login_form").bind("ajax:error", function(event, data, status, xhr) {
-        $("#notifications").html("<div class=\'error\'>\n <p class=\'text\'>#{t("user_sessions.flash.warning.login_failed")}<\/p>\n<\/div>\n");
-        $('form .spinner').fadeOut('fast');
-      });
-    });
-  /[if lt IE 9]
-
-= content_for :title do
-  = t("layout.appname")
-  = "| #{@title}" unless @title.blank?
-
-= content_for :notifications do
-  = render :partial => 'notifications' if flash[:warning].present?
-
-= content_for :login_logo do
-  = image_tag 'login-card-logo-upstream.png'
-
-= content_for :footer do
-  = render :partial => 'layouts/footer'
+= content_for(:content) do
+  = render :partial => "layouts/converge-ui/login_layout",
+           :locals => { :login_form_path_string => user_sessions_path,
+                        :recovery_strings => t("user_sessions.recovery_link_html",
+                                               :username => link_to( t("user_sessions.username"),
+                                                                     login_path(:card => :username_recovery),
+                                                                     :id => 'username_link' ),
+                                               :password => link_to( t("user_sessions.password"),
+                                                                     login_path(:card => :password_reset),
+                                                                     :id => 'password_link' )),
+                        :login_path_string => login_path,
+                        :new_username_recoveries_form_path_string => username_recoveries_path,
+                        :new_password_resets_form_path_string => password_resets_path }

--- a/src/app/views/username_recoveries/create.js.erb
+++ b/src/app/views/username_recoveries/create.js.erb
@@ -1,0 +1,4 @@
+$('.card#username_recovery').animate({ 'left' : '-360px' }, 'slow', function(){
+  $(this).css('z-index', -1);
+});
+$('#notifications').html("<%= escape_javascript render(:partial => 'user_sessions/notifications') %>");

--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -65,6 +65,9 @@ module Conductor
     require File.dirname(__FILE__) + '/../lib/exceptions'
     require File.dirname(__FILE__) + '/../lib/image'
 
+    # Read settings config (accessible at Conductor::Application::SETTINGS_CONFIG)
+    ::SETTINGS_CONFIG = YAML.load_file("#{::Rails.root.to_s}/config/settings.yml")
+
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password, :password_confirmation]
 

--- a/src/config/environments/development.rb
+++ b/src/config/environments/development.rb
@@ -30,8 +30,20 @@ Conductor::Application.configure do
   #config.action_view.debug_rjs             = true
   config.action_controller.perform_caching = false
 
+  #Mailer configuration
+  config.action_mailer.delivery_method = SETTINGS_CONFIG[:action_mailer][:delivery_method].to_sym
+  if SETTINGS_CONFIG[:smtp_settings] == :smtp
+    config.action_mailer.smtp_settings = SETTINGS_CONFIG[:action_mailer][:smtp_settings]
+  end
+
+  ActionMailer::Base.default :from => SETTINGS_CONFIG[:action_mailer][:default_from]
+  config.action_mailer.perform_deliveries = true
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.default_url_options = {
+    :protocol => SETTINGS_CONFIG[:action_mailer][:default_url_options][:protocol],
+    :host => SETTINGS_CONFIG[:action_mailer][:default_url_options][:host]
+  }
 
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log
@@ -41,4 +53,5 @@ Conductor::Application.configure do
 
   # Otherwise we eat these connections even outside of tests:
   WebMock.allow_net_connect! if defined?(WebMock)
+
 end

--- a/src/config/environments/production.rb
+++ b/src/config/environments/production.rb
@@ -51,8 +51,19 @@ Conductor::Application.configure do
   # Enable serving of images, stylesheets, and javascripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
 
+  #Mailer configuration
+  config.action_mailer.delivery_method = SETTINGS_CONFIG[:action_mailer][:delivery_method].to_sym
+  if SETTINGS_CONFIG[:smtp_settings] == :smtp
+    config.action_mailer.smtp_settings = SETTINGS_CONFIG[:action_mailer][:smtp_settings]
+  end
+  ActionMailer::Base.default :from => SETTINGS_CONFIG[:action_mailer][:default_from]
+  config.action_mailer.perform_deliveries = true
   # Disable delivery errors, bad email addresses will be ignored
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.default_url_options = {
+    :protocol => SETTINGS_CONFIG[:action_mailer][:default_url_options][:protocol],
+    :host => SETTINGS_CONFIG[:action_mailer][:default_url_options][:host]
+  }
 
   # Enable threaded mode
   # config.threadsafe!

--- a/src/config/environments/test.rb
+++ b/src/config/environments/test.rb
@@ -40,6 +40,10 @@ Conductor::Application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = {
+    :protocol => SETTINGS_CONFIG[:action_mailer][:default_url_options][:protocol],
+    :host => SETTINGS_CONFIG[:action_mailer][:default_url_options][:host]
+  }
 
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,

--- a/src/config/locales/emails/en.yml
+++ b/src/config/locales/emails/en.yml
@@ -1,0 +1,10 @@
+en:
+  user_mailer:
+    password_reset:
+      subject: "Password reset"
+      request_received: "A request has been received to reset the Conductor password for user %{username}. In order to reset this password, click the URL below."
+      ignore: "If you did not request this password to be reset, just ignore this email and the password will stay the same."
+    send_usernames:
+      subject: "Conductor Usernames"
+      request_received: "A request has been received by Conductor server %{url} to retrieve the logins for email %{email}. The following is a list of those logins:"
+

--- a/src/config/locales/en.yml
+++ b/src/config/locales/en.yml
@@ -164,21 +164,12 @@ en:
       local: "Locally-managed User Groups"
       ldap: "LDAP-managed User Groups"
   user_sessions:
-    new:
-      username: "Username"
-      password: "Password"
-      show_password: Show my password
-      login_assistance: Login Assistance
-      security_info: Security Info
-      login: Login
-      help: "Help functionality is not yet available."
-      forgot: Forgot
-      or: or
-      login_unknown_info: "If you do not know your username, please enter your email address below. Your username will be sent."
-      return_to_login: "Return to log in"
-      send_login: "Send Login"
-      password_unknown_info: "Please enter your username and email address below. Instructions on resetting your password will be sent."
-      reset_password: "Reset Password"
+    noscript: "Please enable Javascript for full functionality."
+    username: "Username"
+    password: "Password"
+    login: Login
+    recovery_link_html: "Forgot %{username} or %{password}?"
+
     security:
       encrypted_connection: Encrypted Connection
       unencrypted_connection:  Unencrypted Connection
@@ -192,6 +183,27 @@ en:
     flash:
       warning:
         login_failed: "The Username or Password is incorrect, please try again."
+
+  password_resets:
+    reset_instructions_sent: "Instructions for resetting your password have been emailed."
+    reset_password: "Reset Password"
+    password_unknown: "Forgot your password?"
+    password_unknown_info: "Enter your username and email address below and instructions on resetting your password will be sent to you."
+    email_address: "Email"
+    change_password: "Change Password"
+    change_password_info: "Enter your new password to change your password."
+    new_password: "New password"
+    confirm_password: "Confirm Password"
+    passwords_do_not_match: "Passwords do not match."
+    password_reset_success: "Password has been successfuly reset. Please log in."
+    password_reset_expired: "Your Password reset link has expired. Please re-apply for the new password reset by filling the form below."
+    invalid_token: "The Password Reset link is no longer valid. Please re-apply for the new link by completing the form below."
+  username_recoveries:
+    recover_usernames: "Recover Usernames"
+    username_unknown: "Username unknown?"
+    username_unknown_info: "If you do not know your username, please enter your email address below and usernames bound to your email will be sent to you."
+    usernames_sent: "Usernames have been sent to given e-mail address."
+
   about: About
   configure: Configure
   hello: Hello

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -71,12 +71,16 @@ Conductor::Application.routes.draw do
   # Note: This route will make all actions in every controller accessible via GET requests.
   # match ':controller(/:action(/:id(.:format)))'
 
-  resource :user_session
+  resource :user_sessions
   match 'login',       :to => 'user_sessions#new',     :as => 'login'
   match 'logout',      :to => 'user_sessions#destroy', :as => 'logout'
   match 'register',    :to => 'users#new',             :as => 'register'
 
   resource  'account', :to => 'users'
+
+  resources :password_resets, :only => [:create, :edit, :update]
+  resources :username_recoveries, :only => [:create]
+
   resources :templates
   resources :permissions do
     collection do

--- a/src/config/settings.yml
+++ b/src/config/settings.yml
@@ -22,3 +22,20 @@
 
 :session:
   :timeout: 15 # minutes
+
+:action_mailer:
+  :delivery_method: sendmail # or smtp
+  # use this configuration if you use smtp as delivery_method
+  # :smtp_settings:
+  #   :address: smtp.gmail.com
+  #   :port: 587
+  #   :domain: example.aeolusproject.org
+  #   :user_name: <username>,
+  #   :password: <password>
+  #   :authentication: plain
+  #   :enable_starttls_auto: true
+  :default_url_options:
+    :host: localhost/conductor
+    :protocol: https
+  :default_from: admin@aeolusproject.org
+  :password_reset_token_timeout: 120 #minutes

--- a/src/db/migrate/20120920080703_add_password_reset_to_users.rb
+++ b/src/db/migrate/20120920080703_add_password_reset_to_users.rb
@@ -1,0 +1,11 @@
+class AddPasswordResetToUsers < ActiveRecord::Migration
+  def self.up
+    add_column :users, :password_reset_token, :string
+    add_column :users, :password_reset_sent_at, :datetime
+  end
+
+  def self.down
+    remove_column :users, :password_reset_sent_at
+    remove_column :users, :password_reset_token
+  end
+end

--- a/src/features/step_definitions/user_steps.rb
+++ b/src/features/step_definitions/user_steps.rb
@@ -23,6 +23,13 @@ Given /^there are (\d+) users$/ do |number|
   User.count.should == number.to_i
 end
 
+Given /^user "([^"]*)" has valid password reset token "([^"]*)"$/ do |username, password_reset_token|
+  user = User.find_by_username(username)
+  user.password_reset_token = password_reset_token
+  user.password_reset_sent_at = Time.zone.now
+  user.save
+end
+
 Then /^there should be (\d+) users?$/ do |number|
   User.count.should == number.to_i
 end

--- a/src/features/support/paths.rb
+++ b/src/features/support/paths.rb
@@ -32,6 +32,9 @@ module NavigationHelpers
     when /the login page/
       login_path
 
+    when /the password reset page with token "([^"]*)"$/i
+      edit_password_reset_path($1)
+
     when /^(.*)'s user page$/i
        user_path(User.find_by_username($1))
 
@@ -53,7 +56,7 @@ module NavigationHelpers
       account_path
 
     when /the login error page/
-      user_session_path
+      user_sessions_path
 
     when /the providers page/
       url_for :controller => 'providers', :action => 'index', :only_path => true

--- a/src/features/user_sessions.feature
+++ b/src/features/user_sessions.feature
@@ -11,3 +11,46 @@ Feature: User sessions
     Given I visit the images page
     And I login
     Then I should be on the images page
+
+  Scenario: Retrieve forgotten username
+    Given there is a user "admin"
+    And I am on the login page
+    And I follow "username_link"
+    Then I should have the following query string:
+      | card | username_recovery |
+    And I should see "Username unknown?"
+    And I fill in "email" with "admin@example.com"
+    And I press "Recover Usernames"
+    Then I should see "Usernames have been sent to given e-mail address."
+
+  Scenario: Request for the forgotten password reset
+    Given there is a user "admin"
+    And I am on the login page
+    And I follow "password_link"
+    Then I should have the following query string:
+      | card | password_reset |
+    And I should see "Forgot your password?"
+    And I fill in "username" with "admin"
+    And I fill in "email" with "admin@example.com"
+    And I press "Reset Password"
+    Then I should see "Instructions for resetting your password have been emailed."
+
+  Scenario: Change password using the reset token from email
+    Given there is a user "admin"
+    And user "admin" has valid password reset token "some_random_string"
+    When I go to the password reset page with token "some_random_string"
+    Then I should see "Change Password"
+    When I fill in "password_field" with "my_new_password"
+    And I fill in "confirm_field" with "my_new_password"
+    And I press "Change Password"
+    Then I should see "Password has been successfuly reset. Please log in."
+
+  Scenario: I passwords don't match when changing password with reset token
+    Given there is a user "admin"
+    And user "admin" has valid password reset token "some_random_string"
+    When I go to the password reset page with token "some_random_string"
+    Then I should see "Change Password"
+    When I fill in "password_field" with "my_new_password"
+    And I fill in "confirm_field" with "my_new_different_password"
+    And I press "Change Password"
+    And I should see "Password doesn't match confirmation"

--- a/src/spec/controllers/password_resets_controller_spec.rb
+++ b/src/spec/controllers/password_resets_controller_spec.rb
@@ -1,0 +1,71 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+require 'spec_helper'
+
+describe PasswordResetsController do
+  fixtures :all
+  before(:each) do
+    @tuser = FactoryGirl.create :tuser
+    @tuser.password_reset_token = "random_token_asdklfjasdlfkjadf"
+    @tuser.password_reset_sent_at = Time.zone.now
+    mock_warden(nil)
+  end
+
+  describe "#create" do
+    before (:each) do
+      @params = { :username => @tuser.username, :email => @tuser.email }
+
+      User.stub!(:find_by_username_and_email).and_return(@tuser)
+      @tuser.stub!(:send_password_reset).and_return(true)
+    end
+
+    it "should send an email with password reset details" do
+      @tuser.should_receive(:send_password_reset)
+      post :create, @params
+      response.should redirect_to(login_path)
+    end
+  end
+
+  describe "#edit" do
+    before (:each) do
+      User.stub!(:find_by_password_reset_token!).and_return(@tuser)
+    end
+
+    it "successfully renders password reset edit page" do
+      get :edit, :id => @tuser.password_reset_token
+      response.should render_template :edit
+    end
+  end
+
+  describe "#update" do
+    before (:each) do
+      @new_password = "mynewpassword"
+      @params = {:id => @tuser.password_reset_token, :user => {:password => @new_password, :password_confirmation => @new_password}}
+
+      User.stub!(:find_by_password_reset_token!).and_return(@tuser)
+      @tuser.stub!(:update_attributes).and_return true
+    end
+
+    it "should update the user's password and reset the token details" do
+      @tuser.should_receive(:update_attributes).
+          with("password" => @new_password, "password_confirmation" => @new_password, "password_reset_token" => nil, "password_reset_sent_at" => nil)
+      put :update, @params
+      response.should redirect_to(login_path)
+    end
+  end
+
+end

--- a/src/spec/controllers/username_recoveries_controller_spec.rb
+++ b/src/spec/controllers/username_recoveries_controller_spec.rb
@@ -1,0 +1,40 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+require 'spec_helper'
+
+describe UsernameRecoveriesController do
+  fixtures :all
+  before(:each) do
+    @tuser = FactoryGirl.create :tuser
+    mock_warden(nil)
+    Delayed::Worker.delay_jobs = false
+  end
+
+  describe "#create" do
+    before (:each) do
+      User.stub_chain(:find_all_by_email, :map).and_return([@tuser.id])
+      UserMailer.stub(:delay).and_return(UserMailer)
+      UserMailer.stub(:send_usernames)
+    end
+
+    it "should send an email with usernames related to user email" do
+      UserMailer.should_receive(:send_usernames)
+      post :create, :email => @tuser.email
+      response.should redirect_to(login_path)
+    end
+  end
+end


### PR DESCRIPTION
This patchset adds Username and Password recovery functionality to conductor.

To make emails work properly, it is necessary to update configuration in src/config/settings.yml (for developement) or /etc/aeolus-conductor/settings.yml (for production). 

It is necessary to set the action_mailer.default_from to valid and existing email address, to make the email actually sent. Next action_mailer.default_url_options.host and protocol serve for the links used in email texts. If one of these is set wrong, the links used in emails (like link to page for changing the password using password reset token) will not lead to the right url.
