### PR TITLE
Make dc:setup print admin user password  to console

### DIFF
--- a/src/lib/tasks/dc_tasks.rake
+++ b/src/lib/tasks/dc_tasks.rake
@@ -24,7 +24,7 @@ namespace :dc do
                     :quota => Quota.new)
     registration = RegistrationService.new(user)
     if registration.save
-      puts "User #{args.username} registered"
+      puts "User '#{args.username}' with password '#{args.password}' registered"
     else
       puts "User registration failed: #{registration.error}"
     end


### PR DESCRIPTION
Last night I was trying to setup Conductor from GIT on my machine and I forgot the default 'admin' password (created by "rake dc:setup"). This patch just simply print the password to console, so new contributors will not need to look into code or search on site for it :-)
