### PR TITLE
New flash messages

### DIFF
--- a/src/app/controllers/api/images_controller.rb
+++ b/src/app/controllers/api/images_controller.rb
@@ -45,7 +45,7 @@ module Api
     end
 
     def create
-      @errors=[]
+      @errors = []
       req = process_post(request.body.read)
       begin
         if req[:type] == :failed

--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -232,7 +232,9 @@ class ApplicationController < ActionController::Base
     respond_to do |format|
       format.html do
         store_location
-        flash[:notice] = t('application_controller.flash.notice.must_be_logged')
+        unless session[:return_to] == root_path # don't display notice if going to root
+          flash[:warning] = t('application_controller.flash.notice.must_be_logged')
+        end
         redirect_to login_url
       end
       format.js { head :unauthorized }

--- a/src/app/controllers/images_controller.rb
+++ b/src/app/controllers/images_controller.rb
@@ -235,7 +235,7 @@ class ImagesController < ApplicationController
     @environment = PoolFamily.find(params[:environment])
     check_permissions
     @name = params[:name]
-    errors = Array.new
+    errors = []
 
     if @name.empty?
       errors << t('images.flash.error.no_name')

--- a/src/app/models/template_xml.rb
+++ b/src/app/models/template_xml.rb
@@ -41,12 +41,8 @@ class TemplateXML
   end
 
   def self.validate(xmlstr)
-    begin
-      doc = TemplateXML.new(xmlstr)
-    rescue Nokogiri::XML::SyntaxError => e
-      return [e.message]
-    end
-    return doc.validate
+    doc = TemplateXML.new(xmlstr)
+    doc.validate[:failures].to_a
   end
 
   def name=(name)

--- a/src/app/models/template_xml.rb
+++ b/src/app/models/template_xml.rb
@@ -19,7 +19,7 @@ class TemplateXML
   attr_reader :errors, :doc
 
   def initialize(xmlstr)
-    @errors = []
+    @errors = {}
     @xml = Nokogiri::XML(xmlstr) { |config| config.strict }
     @relax_file = "#{::Rails.root.to_s}/app/util/template-rng.xml"
   end
@@ -28,10 +28,15 @@ class TemplateXML
     xsd = Nokogiri::XML::RelaxNG(File.read(@relax_file))
     errors = xsd.validate(@xml).map {|err| err.message}
     if errors.any?
-      @errors << I18n.t('template_xml.errors.invalid_xml')
-      @errors += errors
+      @errors[:summary] = I18n.t('template_xml.errors.invalid_xml')
+      @errors[:failures] = errors
     end
-    @errors << I18n.t('template_xml.errors.name_is_not_set') if @xml.xpath('/template/name').text.empty?
+    # TODO would be much better to validate name presence using rng template^
+    if @xml.xpath('/template/name').text.empty?
+      @errors[:summary] ||= I18n.t('template_xml.errors.invalid_xml')
+      @errors[:failures] ||= []
+      @errors[:failures] << I18n.t('template_xml.errors.name_is_not_set')
+    end
     @errors
   end
 

--- a/src/app/stylesheets/layout.scss
+++ b/src/app/stylesheets/layout.scss
@@ -104,60 +104,6 @@ Textual Labels -- v.0.0.1 [label] (label.scss)
 }
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Alert Flash -- v.0.0.1 [flash] (flash.scss)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
-#flash-hud{
-  width: 912px;
-  margin: 0 auto;
-  background-color: #ddd;
-  -webkit-border-radius: 0px 0px 7px 7px;
-  -moz-border-radius: 0px 0px 7px 7px;
-  border-radius: 0px 0px 7px 7px;
-  border: 1px solid #999;
-  padding: 8px;
-
-  a.control{
-    float: right;
-    color: #999;
-    font-size: 11px;
-  }
-
-  .flash-group{
-    display: table;
-  }
-
-  .flash-subset{
-    display: table-row;
-
-    div.heading{
-      display: inline;
-      text-align: right;
-      border-right: 1px solid #ccc;
-      padding-right: 8px;
-      width: 20px;
-    }
-
-    ul{
-      @include display_inline_block;
-      font-size: 12px;
-      padding-left: 8px;
-      list-style: none;
-
-      li + li{
-        margin-top: 6px;
-      }
-    }
-
-  }
-
-  .flash-group + .flash-group{
-    margin-top: 10px;
-  }
-
-}
-
-/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Hover link popup-- v.0.0.1
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 

--- a/src/app/stylesheets/login.scss
+++ b/src/app/stylesheets/login.scss
@@ -8,7 +8,7 @@ article{
   #notifications{
     position: relative;
 
-    div.error, div.notice, div.alert{
+    div.error, div.notice, div.warning{
       position: absolute;
       bottom: 15px;
       @include box-sizing(border-box);
@@ -42,7 +42,7 @@ article{
       }
     }
     div.notice p:before{ background: image-url("converge-ui/icons/success_icon.png") no-repeat 0 0; }
-    div.alert p:before{ background: image-url("converge-ui/icons/warning_icon.png") no-repeat 0 0; }
+    div.warning p:before{ background: image-url("converge-ui/icons/warning_icon.png") no-repeat 0 0; }
   }
 
   .container section .card{

--- a/src/app/views/layouts/_error_messages.html.haml
+++ b/src/app/views/layouts/_error_messages.html.haml
@@ -1,10 +1,8 @@
 - content_for :error_messages do
-  .error.flash-group
-    .flash-subset
-      %div.heading
-        =image_tag 'flash_warning_icon.png', :alt => 'Errors'
-      %ul.flashes
-        %li
-          %strong= t("errors.template.header", :model => object.class.model_name.human, :count => object.errors.count)
+  .flash_hud
+    %a.control{ :href => "#", :title => t("close") }
+    %ul.flash_messages.error
+      %li= t("errors.template.header", :model => object.class.model_name.human, :count => object.errors.count)
+      %ul
         - object.errors.full_messages.each do |msg|
           %li= msg

--- a/src/app/views/layouts/_new_notification.html.haml
+++ b/src/app/views/layouts/_new_notification.html.haml
@@ -1,88 +1,81 @@
-#flash-hud
-  = link_to "Close","#", :class => "control"
-  - unless flash.empty?
-    -if flash[:success]
-      .notice.flash-group
-        .flash-subset
-          %div.heading
-            =image_tag 'flash_notice_icon.png', :alt => 'Notices'
-          %ul.flashes
-            %li= flash[:success]
+-# Possible flash message possible structures:
+-# flash[:warning] = "warning message"
+-# flash[:warning] = ["warning message", "warning message"]
+-# flash[:notice] = "notice message"
+-# flash[:notice] = ["notice message", "notice message"]
+-# flash[:success] = "success message"
+-# flash[:success] = ["success message", "notice message"]
+-# flash[:error] = "error message"
+-# flash[:error] = [t("error message"), t("error message")]
+-# flash[:error] = {
+-#   :summary => "error message summary",
+-#   :failures => [ "error message", "error message", "error message" ]
+-#   or
+-#   :failures => { :a => "error message", :b => "error message", :c => "error message" }
+-#   or
+-#   :failures => "error message"
+-# }
 
-    -if flash[:notice]
-      .notice.flash-group
-        .flash-subset
-          %div.heading
-            =image_tag 'flash_notice_icon.png', :alt => 'Notices'
-          %ul.flashes
-            -if flash[:notice].kind_of?(Array)
-              -flash[:notice].each do |msg|
-                %li= msg
-            -else flash[:notice]
-              %li= flash[:notice]
+- unless flash.empty?
+  - if flash[:success]
+    .flash_hud
+      %a.control{ :href => "#", :title => t("close") }
+      %ul.error_messages.success
+        - if flash[:success].kind_of?(Array)
+          -flash[:success].each do |msg|
+            %li= msg
+        - else
+          %li= flash[:success]
 
-    -if flash[:warning]
-      .warning.flash-group
-        .flash-subset
-          %div.heading
-            =image_tag 'flash_warning_icon.png', :alt => 'Warnings'
-          %ul.flashes
-            -if flash[:warning].kind_of?(Array)
-              - flash[:warning].each do |k, v|
-                %li= [k, v.present? ? ": #{v}" : '']
-            -else
-              %li= flash[:warning]
+  - if flash[:notice]
+    .flash_hud
+      %a.control{ :href => "#", :title => t("close") }
+      %ul.error_messages.success
+        - if flash[:notice].kind_of?(Array)
+          -flash[:notice].each do |msg|
+            %li= msg
+        - else
+          %li= flash[:notice]
 
-    -if flash[:error]
-      -if flash[:error].kind_of?(String)
-        .error.flash-group
-          .flash-subset
-            %div.heading
-              =image_tag 'flash_error_icon.png', :alt => 'Errors'
-            =flash[:error]
-      -elsif flash[:error].kind_of?(Hash)
-        -unless flash[:error][:successes].blank?
-          .notice.flash-group
-            .flash-subset
-              %div.heading
-                =image_tag 'flash_notice_icon.png', :alt => 'Notices'
-              %ul.flashes
-                - flash[:error][:successes].each do |k, v|
-                  %li= [k, v.present? ? ": #{v}" : '']
-        .error.flash-group
-          -if !flash[:error][:summary].blank?
-            .flash-subset
-              %div.heading
-                =image_tag 'flash_warning_icon.png', :alt => 'Warnings'
-              %ul.flashes
-                %li= flash[:error][:summary]
-          .flash-subset
-            %div.heading
-              =image_tag 'flash_error_icon.png', :alt => 'Errors'
-            %ul.flashes
-              - if !flash[:error][:failures].blank?
-                - flash[:error][:failures].each do |failure|
-                  - if failure.is_a?(Hash)
-                    %li
-                      = failure.key
-                      - if failure.value.present?
-                        = ": #{failure.value}"
-                  - elsif failure.is_a?(Array)
-                    - failure.each do |msg|
-                      %li= msg
-                  -else
-                    %li= flash[:error][:failures]
+  - if flash[:warning]
+    .flash_hud
+      %a.control{ :href => "#", :title => t("close") }
+      %ul.flash_messages.warning
+        - if flash[:warning].kind_of?(Array)
+          - flash[:warning].each do |msg|
+            %li= msg
+        - else
+          %li= flash[:warning]
+
+  - if flash[:error]
+    .flash_hud
+      %a.control{ :href => "#", :title => t("close") }
+      - if flash[:error].kind_of?(Hash)
+        %ul.flash_messages.error
+          - if flash[:error][:summary].present?
+            %li= flash[:error][:summary]
+          %ul
+            - if flash[:error][:failures].present?
+              - if flash[:error][:failures].is_a?(Hash)
+                - flash[:error][:failures].each do |key, value|
+                  %li
+                    = key
+                    = ": #{value}" if value.present?
+              - elsif flash[:error][:failures].is_a?(Array)
+                - flash[:error][:failures].each do |msg|
+                  %li= msg
               - else
-                -flash[:error].each do |e|
-                  %li= e
-      -elsif flash[:error].kind_of?(Array)
-        .error.flash-group
-          .flash-subset
-            %div.heading
-              =image_tag 'flash_error_icon.png', :alt => 'Errors'
-            %ul.flashes
-              -flash[:error].each do |msg|
-                %li= msg
+                %li= flash[:error][:failures]
+            - else
+              -flash[:error].each do |e|
+                %li= e
+      - elsif flash[:error].kind_of?(Array)
+        %ul.flash_messages.error
+          - flash[:error].each do |msg|
+            %li= msg
+      - else
+        %ul.flash_messages.error
+          %li= flash[:error]
 
-  - if content_for? :error_messages
-    = yield :error_messages
+- if content_for? :error_messages
+  = yield :error_messages

--- a/src/app/views/layouts/_new_notification.html.haml
+++ b/src/app/views/layouts/_new_notification.html.haml
@@ -20,7 +20,7 @@
   - if flash[:success]
     .flash_hud
       %a.control{ :href => "#", :title => t("close") }
-      %ul.error_messages.success
+      %ul.flash_messages.success
         - if flash[:success].kind_of?(Array)
           -flash[:success].each do |msg|
             %li= msg
@@ -30,7 +30,7 @@
   - if flash[:notice]
     .flash_hud
       %a.control{ :href => "#", :title => t("close") }
-      %ul.error_messages.success
+      %ul.flash_messages.success
         - if flash[:notice].kind_of?(Array)
           -flash[:notice].each do |msg|
             %li= msg

--- a/src/app/views/layouts/_simple_form_error_messages.html.haml
+++ b/src/app/views/layouts/_simple_form_error_messages.html.haml
@@ -1,8 +1,5 @@
 - content_for :error_messages do
-  .error.flash-group
-    .flash-subset
-      %div.heading
-        =image_tag 'flash_warning_icon.png', :alt => 'Errors'
-      %ul.flashes
-        %li
-          %strong= t("simple_form.error_notification.default_message", :model => object.class.model_name.human)
+  .flash_hud
+    %a.control{ :href => "#", :title => t("close") }
+    %ul.flash_messages.error
+      %li= t("simple_form.error_notification.default_message", :model => object.class.model_name.human)

--- a/src/app/views/layouts/application.html.haml
+++ b/src/app/views/layouts/application.html.haml
@@ -23,6 +23,7 @@
     window.history.replaceState || (window.history.replaceState = function(){});
 
   = javascript_include_tag "converge-ui/vendor/jquery/jquery-1.6.2.js"
+  = javascript_include_tag "converge-ui/flash_messages.js"
   = javascript_include_tag "jquery.ui-1.8.1/jquery-ui-1.8.1.custom.min.js"
   = javascript_include_tag "mustache.min.js"
   = javascript_include_tag "underscore-min.js"
@@ -53,7 +54,7 @@
       %li.header-widget= link_to t('masthead.login'), login_path
 
 = content_for :content do
-  = render :partial => '/layouts/new_notification' if flash.present? or content_for?(:error_messages)
+  = render :partial => '/layouts/new_notification'# if flash.present? or content_for?(:error_messages)
   = yield
 
 = content_for :footer do

--- a/src/app/views/user_sessions/_notifications.html.haml
+++ b/src/app/views/user_sessions/_notifications.html.haml
@@ -1,11 +1,11 @@
--if flash[:warning]
+-if flash[:error]
   .error
-    %p.text= flash[:warning]
+    %p.text= flash[:error]
 - if flash[:notice]
   .notice
     %p.text= flash[:notice]
-- if flash[:alert]
-  .alert
-    %p.text= flash[:alert]
+- if flash[:warning]
+  .warning
+    %p.text= flash[:warning]
 - if content_for?(:error_messages)
   = yield :error_messages

--- a/src/config/locales/en.yml
+++ b/src/config/locales/en.yml
@@ -255,6 +255,7 @@ en:
   reset: Reset
   create_account: Create Account
   cancel: Cancel
+  close: Close
   back: Back
   choose_name: Choose a username
   choose_password: Choose a password
@@ -1534,7 +1535,7 @@ en:
     flash:
       notice:
         record_not_exist: "The record you tried to access does not exist. It may have been deleted"
-        must_be_logged: You must be logged in to access this page
+        must_be_logged: "Please log in first."
         must_not_be_logged: You must be logged out to access this page
       error:
         no_url_provided: No URL is provided for XML import

--- a/src/features/provider_account.feature
+++ b/src/features/provider_account.feature
@@ -84,7 +84,7 @@ Feature: Manage Provider Accounts
     When I follow "Edit"
     And I fill in "provider_account[label]" with "testaccount_updated"
     And I press "Save"
-    Then I should see "Provider Account updated" within ".flashes"
+    Then I should see "Provider Account updated" within ".flash_hud .flash_messages"
 
   Scenario: Edit a existing Provider Account with invalid credentials
     Given there is a provider named "mockprovider"

--- a/src/features/step_definitions/general_steps.rb
+++ b/src/features/step_definitions/general_steps.rb
@@ -18,15 +18,15 @@ Then /^I should see an input "([^\"]*)"$/ do |value|
 end
 
 Then /^I should see a confirmation message$/ do
-  page.should have_selector '.flash-group.notice .flash-subset'
+  page.should have_selector '.flash_hud .flash_messages.success'
 end
 
 Then /^I should see a warning message$/ do
-  page.should have_selector '.flash-group.warning .flash-subset'
+  page.should have_selector '.flash_hud .flash_messages.warning'
 end
 
 Then /^I should see an error message$/ do
-  page.should have_selector '.flash-group.error .flash-subset'
+  page.should have_selector '.flash_hud .flash_messages.error'
 end
 
 module LocalizationHelpers

--- a/src/public/javascripts/application.js
+++ b/src/public/javascripts/application.js
@@ -143,13 +143,6 @@ $.extend(Conductor, {
     });
   },
 
-  closeNotification: function() {
-    $('.control').click(function(e) {
-      e.preventDefault();
-      $('#flash-hud').slideUp(100).fadeOut(100);
-    });
-  },
-
   toggleCollapsible: function() {
     $('.collapse').click(function(e) {
       e.preventDefault();
@@ -317,7 +310,6 @@ $(document).ready(function () {
   Conductor.enhanceDetailsTabs();
   Conductor.bindPrettyToggle();
   Conductor.multiActionValidation();
-  Conductor.closeNotification();
   Conductor.toggleCollapsible();
   Conductor.selectAllCheckboxes();
   Conductor.tabAjaxRequest();


### PR DESCRIPTION
This patchset implements new flash messsages from converge-ui

The positioning of the flash messages remained the same (which is not optimal), the proper positioning will be part of upcoming UI changes.

Possible flash message structures:
flash[:warning] = "warning message"
flash[:warning] = ["warning message", "warning message"]
flash[:notice] = "notice message"
flash[:notice] = ["notice message", "notice message"]
flash[:success] = "success message"
flash[:success] = ["success message", "success message"]
flash[:error] = "error message"
flash[:error] = [t("error message"), t("error message")]
flash[:error] = {
  :summary => "error message summary",
  :failures => [ "error message", "error message", "error message" ]
  or
  :failures => { :a => "error message", :b => "error message", :c => "error message" }
  or
  :failures => "error message"
}
