### PR TITLE
add hardware profile to matches for provider selection

### DIFF
--- a/src/lib/provider_selection/match.rb
+++ b/src/lib/provider_selection/match.rb
@@ -23,6 +23,7 @@ module ProviderSelection
 
     attr_reader :score
     attr_accessor :provider_account
+    attr_accessor :hardware_profile
 
     def initialize(attributes)
       attributes.each do |name, value|

--- a/src/lib/provider_selection/priority_group.rb
+++ b/src/lib/provider_selection/priority_group.rb
@@ -30,17 +30,9 @@ module ProviderSelection
       priority_group = PriorityGroup.new(obj.score)
 
       possible_provider_accounts = obj.all_provider_accounts
-      allowed_provider_accounts = allowed_matches.map do |match|
-        match.provider_account
-      end.uniq
-
-      possible_provider_accounts &= allowed_provider_accounts
-
-      return nil if possible_provider_accounts.empty?
-
-      possible_provider_accounts.each do |provider_account|
-        priority_group.matches << Match.new(:provider_account => provider_account)
-      end
+      priority_group.matches = allowed_matches.find_all { |match| 
+        possible_provider_accounts.include?( match.provider_account )
+      }
 
       priority_group
     end

--- a/src/spec/lib/provider_selection/base.rb
+++ b/src/spec/lib/provider_selection/base.rb
@@ -43,6 +43,7 @@ describe ProviderSelection::Base do
   it "should give back valid match" do
     match = @provider_selection.next_match
     match.provider_account.should eql(@account2)
+    match.hardware_profile.should_not be_nil
   end
 
   it "should find common provider account" do


### PR DESCRIPTION
on the road to enable cost-based provider selection this small patch adds hardware profile to each match for provider selection so that provider selection strategies can look not only at provider accounts but also at the hardware profiles when calculating the scores

please do not leave this pull request hanging like the 2 trivial pull request that I have created 3 weeks ago
