### PR TITLE
test for issue #177

### DIFF
--- a/src/app/views/pools/show.html.haml
+++ b/src/app/views/pools/show.html.haml
@@ -8,7 +8,7 @@
                 :id => 'new_deployment_button'
     .catalog_link
       = render :partial => 'layouts/catalog_dropdown', :locals => {:catalogs => @catalogs}
-    = link_to t('pool_families.index.provider_selection'), pool_provider_selection_path(@pool), :class => 'button primary'
+    = link_to t('pool_families.index.provider_selection'), pool_provider_selection_path(@pool), :class => 'button primary', :id => 'provider_selection_button'
     .button-group
       - if check_privilege(Privilege::MODIFY, @pool)
         = link_to t('edit'), edit_pool_path(@pool), :class => 'button', :id => 'edit_pool_button'

--- a/src/features/pool.feature
+++ b/src/features/pool.feature
@@ -7,6 +7,17 @@ Feature: Manage Pools
     Given I am an authorised user
     And I am logged in
 
+  Scenario: Change Provider Selection
+    Given a pool "mockpool" exists
+    Given I am viewing the pool "mockpool"
+    And I follow "provider_selection_button"
+    Then I should be on the provider selection page for "mockpool" pool
+    When I click "penalty_for_failure" toggle
+    Then I should be on the provider selection page for "mockpool" pool
+    When I follow link with text "Configure" 
+    Then I should not see "uninitialized constant"
+# this test is to be alter to check for some text on the page when the bug is fixed
+
   Scenario: Create a new Pool
     Given I am on the pools page
     And there is not a pool named "mockpool"

--- a/src/features/step_definitions/custom_web_steps.rb
+++ b/src/features/step_definitions/custom_web_steps.rb
@@ -13,6 +13,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-When /^(?:|I )follow link with ID "([^"]*)"$/ do |link_id|
+When /^(?:|I )follow link with (?:ID|text) "([^"]*)"$/ do |link_id|
   click_link(link_id)
 end

--- a/src/features/step_definitions/web_steps.rb
+++ b/src/features/step_definitions/web_steps.rb
@@ -225,3 +225,8 @@ end
 Then /^show me the page$/ do
   save_and_open_page
 end
+
+When /^I click "([^"]*)" toggle$/ do |toggle|
+  find(:xpath,"//a[contains(@href,'#{toggle}')]").click
+end
+

--- a/src/features/support/paths.rb
+++ b/src/features/support/paths.rb
@@ -106,6 +106,9 @@ module NavigationHelpers
     when /the launch from the catalog "([^"]*)" page/
       launch_from_catalog_deployments_path(:catalog_id => Catalog.find_by_name($1).id)
 
+    when /the provider selection page for "([^"]*)" pool/
+      pool_provider_selection_path Pool.where(:name => $1).first
+
     when /the instances page/
       instances_path
 


### PR DESCRIPTION
after applying this patch, 'rake cucumber' fails

it should fail, because there is a bug -- issue #177

this patch tests previously untested path in the conductor ui, not only the page with issue #177
