### PR TITLE
add hardware profile to matches for provider selection

### DIFF
--- a/src/lib/provider_selection/base.rb
+++ b/src/lib/provider_selection/base.rb
@@ -55,26 +55,25 @@ module ProviderSelection
       pool = @instances.first.pool
       rank = Rank.new(pool)
 
-      provider_accounts = find_common_provider_accounts.map do |provider_account|
-        provider_account if provider_account.quota.can_start?(@instances)
-      end.uniq.compact
-
       # Adding a priority of 100000 to the default priority group which contains
       # all the available provider accounts.
       # The user defined priority groups has a score between -100 and +100.
       default_priority_group = PriorityGroup.new(100000)
       rank.default_priority_group = default_priority_group
 
-      provider_accounts.each do |provider_account|
+      find_common_provider_accounts.each do |acc_with_hwp|
+        next unless acc_with_hwp.provider_account.quota.can_start?(@instances)
+
         # Rescale to provider account priority to the [-100, 100] interval
-        score = provider_account.priority
+        score = acc_with_hwp.provider_account.priority
         if score.present? && score > Match::UPPER_LIMIT
           score = Match::UPPER_LIMIT
         elsif score.present? && score < Match::LOWER_LIMIT
           score = Match::LOWER_LIMIT
         end
 
-        default_priority_group.matches << Match.new(:provider_account => provider_account,
+        default_priority_group.matches << Match.new(:provider_account => acc_with_hwp.provider_account,
+                                                    :hardware_profile => acc_with_hwp.hardware_profile,
                                                     :score => score)
       end
 
@@ -107,23 +106,30 @@ module ProviderSelection
       @strategy_chain
     end
 
-    private
+    ProviderAccWithHwp = Struct.new(:provider_account, :hardware_profile)
 
+    private
     def find_common_provider_accounts
+
       instance_matches_grouped_by_instances = @instances.map do |instance|
         filter_instance_matches(instance)
       end
 
-      result = []
+      common_accounts = []
       instance_matches_grouped_by_instances.each_with_index do |instance_matches, index|
+        accounts = instance_matches.collect do |instance_match| 
+          ProviderAccWithHwp.new(instance_match.provider_account, instance_match.hardware_profile)
+        end
+
         if index == 0
-          result += instance_matches.map(&:provider_account)
+          common_accounts = accounts
         else
-          result &= instance_matches.map(&:provider_account)
+          provider_accounts = accounts.map(&:provider_account)
+          common_accounts.delete_if{ |pair| ! provider_accounts.include?(pair.provider_account) }
         end
       end
 
-      result
+      common_accounts
     end
 
     def filter_instance_matches(instance)

--- a/src/lib/provider_selection/base.rb
+++ b/src/lib/provider_selection/base.rb
@@ -125,7 +125,7 @@ module ProviderSelection
           common_accounts = accounts
         else
           provider_accounts = accounts.map(&:provider_account)
-          common_accounts.delete_if{ |pair| ! provider_accounts.include?(pair.provider_account) }
+          common_accounts.delete_if{ |pair| !provider_accounts.include?(pair.provider_account) }
         end
       end
 

--- a/src/lib/provider_selection/match.rb
+++ b/src/lib/provider_selection/match.rb
@@ -23,6 +23,7 @@ module ProviderSelection
 
     attr_reader :score
     attr_accessor :provider_account
+    attr_accessor :hardware_profile
 
     def initialize(attributes)
       attributes.each do |name, value|

--- a/src/lib/provider_selection/priority_group.rb
+++ b/src/lib/provider_selection/priority_group.rb
@@ -21,28 +21,23 @@ module ProviderSelection
     attr_accessor :matches
     attr_accessor :score
 
-    def initialize(score)
-      @matches = []
+    def initialize(score, matches=[])
       @score = score
+      @matches = matches
     end
 
     def self.create_from_active_record(obj, allowed_matches)
-      priority_group = PriorityGroup.new(obj.score)
-
       possible_provider_accounts = obj.all_provider_accounts
-      allowed_provider_accounts = allowed_matches.map do |match|
-        match.provider_account
-      end.uniq
 
-      possible_provider_accounts &= allowed_provider_accounts
-
-      return nil if possible_provider_accounts.empty?
-
-      possible_provider_accounts.each do |provider_account|
-        priority_group.matches << Match.new(:provider_account => provider_account)
+      matches = []
+      allowed_matches.each do |match| 
+        if possible_provider_accounts.include?(match.provider_account)
+          matches << Match.new(:provider_account => match.provider_account,
+                               :hardware_profile => match.hardware_profile)
+        end
       end
 
-      priority_group
+      matches.empty? ? nil : PriorityGroup.new(obj.score, matches)
     end
 
     def match_exists?

--- a/src/spec/lib/provider_selection/base.rb
+++ b/src/spec/lib/provider_selection/base.rb
@@ -43,6 +43,7 @@ describe ProviderSelection::Base do
   it "should give back valid match" do
     match = @provider_selection.next_match
     match.provider_account.should eql(@account2)
+    match.hardware_profile.should_not be_nil
   end
 
   it "should find common provider account" do


### PR DESCRIPTION
Imre, please check this variant

there's a potential difference in the behavior in the create_from_active_record method

there's a case where the original implementation would return PriorityGroup with empty matches and the new would return null

not sure if that is right

please check
