### PR TITLE
Deployments API read actions

### DIFF
--- a/src/app/controllers/deployments_controller.rb
+++ b/src/app/controllers/deployments_controller.rb
@@ -242,6 +242,7 @@ class DeploymentsController < ApplicationController
       format.html { render :action => 'show'}
       format.js   { render :partial => @details_tab[:view] }
       format.json { render :json => @deployment }
+      format.xml
     end
   end
 

--- a/src/app/controllers/deployments_controller.rb
+++ b/src/app/controllers/deployments_controller.rb
@@ -453,8 +453,10 @@ class DeploymentsController < ApplicationController
       { :name => t("pools.index.owner"), :sortable => false },
       { :name => t("providers.provider"), :sortable => false }
     ]
-    @pools = Pool.list_for_user(current_session, current_user,
-                                Privilege::CREATE, Deployment)
+
+    pool_scope = params[:pool_id] ? Pool.where(:id => params[:pool_id]) : Pool
+    @pools = pool_scope.list_for_user(current_session, current_user,
+                                      Privilege::CREATE, Deployment)
 
     unpaginated_deployments = Deployment.includes(:owner, :pool, :instances).
       apply_filters(:preset_filter_id => params[:deployments_preset_filter],

--- a/src/app/views/api/entrypoint/index.xml.haml
+++ b/src/app/views/api/entrypoint/index.xml.haml
@@ -2,6 +2,7 @@
 %api{:href => api_url}
   %builds{:href => api_builds_url}
   %catalogs{:href => api_catalogs_url}
+  %deployments{:href => api_deployments_url}
   %images{:href => api_images_url}
   %pools{:href => api_pools_url}
   %pool_families{:href => api_pool_families_url}

--- a/src/app/views/deployments/_detail.xml.haml
+++ b/src/app/views/deployments/_detail.xml.haml
@@ -1,2 +1,10 @@
 !!! XML
-%deployment{:id => deployment.id}
+%deployment{:id => deployment.id, :href => api_deployment_url(deployment)}
+  - unless shallow
+    %name= deployment.name
+    - if deployment.pool && deployment.pool.id
+      %pool{:id => deployment.pool.id, :href => api_pool_url(deployment.pool)}
+    -# TODO: uncomment this and update specs when frontend realms are reachable via API:
+    -# - if deployment.frontend_realm && deployment.frontend_realm.id
+    -#   %frontend_realm{:id => deployment.frontend_realm.id, :href => api_frontend_realm_url(deployment.frontend_realm)}
+    %uuid= deployment.uuid

--- a/src/app/views/deployments/_detail.xml.haml
+++ b/src/app/views/deployments/_detail.xml.haml
@@ -8,3 +8,4 @@
     -# - if deployment.frontend_realm && deployment.frontend_realm.id
     -#   %frontend_realm{:id => deployment.frontend_realm.id, :href => api_frontend_realm_url(deployment.frontend_realm)}
     %uuid= deployment.uuid
+    %scheduled_for_deletion= deployment.scheduled_for_deletion

--- a/src/app/views/deployments/_detail.xml.haml
+++ b/src/app/views/deployments/_detail.xml.haml
@@ -1,0 +1,2 @@
+!!! XML
+%deployment{:id => deployment.id}

--- a/src/app/views/deployments/_list.xml.haml
+++ b/src/app/views/deployments/_list.xml.haml
@@ -1,0 +1,4 @@
+!!! XML
+%deployments
+  - deployments.each do |deployment|
+    =render 'detail', :deployment => deployment, :shallow => shallow

--- a/src/app/views/deployments/index.xml.haml
+++ b/src/app/views/deployments/index.xml.haml
@@ -1,0 +1,2 @@
+!!! XML
+=render 'list', :deployments => @deployments, :shallow => true

--- a/src/app/views/deployments/show.xml.haml
+++ b/src/app/views/deployments/show.xml.haml
@@ -1,0 +1,2 @@
+!!!XML
+=render 'detail', :deployment => @deployment, :shallow => false

--- a/src/app/views/pools/_detail.xml.haml
+++ b/src/app/views/pools/_detail.xml.haml
@@ -10,3 +10,6 @@
   %catalogs
     - catalogs.each do |catalog|
       %catalog{:id => catalog.id, :href => api_catalog_url(catalog)}
+  %deployments
+    - deployments.each do |deployment|
+      %deployment{:id => deployment.id, :href => api_deployment_url(deployment)}

--- a/src/app/views/pools/show.xml.haml
+++ b/src/app/views/pools/show.xml.haml
@@ -1,2 +1,2 @@
 !!! XML
-=render 'detail', :pool => pool, :catalogs => catalogs
+=render 'detail', :pool => pool, :catalogs => catalogs, :deployments => deployments

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -306,7 +306,7 @@ Conductor::Application.routes.draw do
       resources :provider_accounts, :controller => "pool_families_to_provider_accounts_associations", :only => [:index, :show, :update, :destroy]
     end
     resources :catalogs, :only => [:index, :show, :create, :update, :destroy]
-    resources :deployments, :only => [:index]
+    resources :deployments, :only => [:index, :show]
     resources :provider_realms, :only => [:index, :show]
   end
 

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -301,7 +301,9 @@ Conductor::Application.routes.draw do
     resources :provider_accounts, :only => [:index, :create, :show, :update, :destroy]
     resources :provider_types, :only => [:index, :show]
     resources :hardware_profiles, :only => [:index, :show, :destroy, :create]
-    resources :pools, :only => [:index, :show, :create, :update, :destroy]
+    resources :pools, :only => [:index, :show, :create, :update, :destroy] do
+      resources :deployments, :only => [:index]
+    end
     resources :pool_families, :only => [:index, :show, :create, :update, :destroy] do
       resources :provider_accounts, :controller => "pool_families_to_provider_accounts_associations", :only => [:index, :show, :update, :destroy]
     end

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -306,6 +306,7 @@ Conductor::Application.routes.draw do
       resources :provider_accounts, :controller => "pool_families_to_provider_accounts_associations", :only => [:index, :show, :update, :destroy]
     end
     resources :catalogs, :only => [:index, :show, :create, :update, :destroy]
+    resources :deployments, :only => [:index]
     resources :provider_realms, :only => [:index, :show]
   end
 

--- a/src/features/deployment_api.feature
+++ b/src/features/deployment_api.feature
@@ -28,3 +28,13 @@ Feature: Manage Deployments via API
     Given there are some deployments
     When I request a list of deployments returned as XML
     Then I should receive list of those deployments as XML
+
+  Scenario: Get details of a deployment as XML
+    Given there is a deployment
+    When I ask for details of that deployment as XML
+    Then I should receive details of that deployment as XML
+
+  Scenario: Get details of non-existent deployment
+    Given the specified deployment does not exist in the system
+    When I ask for details of that deployment as XML
+    Then I should receive Not Found error

--- a/src/features/deployment_api.feature
+++ b/src/features/deployment_api.feature
@@ -29,6 +29,13 @@ Feature: Manage Deployments via API
     When I request a list of deployments returned as XML
     Then I should receive list of those deployments as XML
 
+  Scenario: Get list of deployments in a pool as XML
+    Given there are some deployments
+    And I have Pool Creator permissions on a pool named "Deployment Pool"
+    And there are some deployments in that pool
+    When I request a list of deployments in that pool returned as XML
+    Then I should receive list of those deployments as XML
+
   Scenario: Get details of a deployment as XML
     Given there is a deployment
     When I ask for details of that deployment as XML

--- a/src/features/deployment_api.feature
+++ b/src/features/deployment_api.feature
@@ -1,0 +1,30 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+@api
+Feature: Manage Deployments via API
+  As a client of conductor
+  In order to manage the full life cycle of deployments in the system
+  I want to be able to Create, Read, Update and Delete deployments via a RESTful API
+
+  Background:
+    Given I am an authorised user
+    And I use my authentication credentials in each request
+
+  Scenario: Get list of deployments as XML
+    Given there are some deployments
+    When I request a list of deployments returned as XML
+    Then I should receive list of those deployments as XML

--- a/src/features/step_definitions/deployment_api_steps.rb
+++ b/src/features/step_definitions/deployment_api_steps.rb
@@ -19,6 +19,11 @@ When /^I request a list of deployments returned as XML$/ do
   get api_deployments_path
 end
 
+When /^I request a list of deployments in that pool returned as XML$/ do
+  header 'Accept', 'application/xml'
+  get api_pool_deployments_path(@pool)
+end
+
 When /^I ask for details of that deployment as XML$/ do
   header 'Accept', 'application/xml'
   get api_deployment_path(@deployment.id)

--- a/src/features/step_definitions/deployment_api_steps.rb
+++ b/src/features/step_definitions/deployment_api_steps.rb
@@ -1,0 +1,28 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+When /^I request a list of deployments returned as XML$/ do
+  header 'Accept', 'application/xml'
+  get api_deployments_path
+end
+
+Then /^I should receive list of those deployments as XML$/ do
+  response = last_response
+  response.headers['Content-Type'].should include('application/xml')
+  response.status.should == 200
+  xml_body = Nokogiri::XML(response.body)
+  xml_body.xpath('//deployments/deployment').size.should == @deployments.size
+end

--- a/src/features/step_definitions/deployment_api_steps.rb
+++ b/src/features/step_definitions/deployment_api_steps.rb
@@ -19,10 +19,24 @@ When /^I request a list of deployments returned as XML$/ do
   get api_deployments_path
 end
 
+When /^I ask for details of that deployment as XML$/ do
+  header 'Accept', 'application/xml'
+  get api_deployment_path(@deployment.id)
+end
+
 Then /^I should receive list of those deployments as XML$/ do
   response = last_response
   response.headers['Content-Type'].should include('application/xml')
   response.status.should == 200
   xml_body = Nokogiri::XML(response.body)
   xml_body.xpath('//deployments/deployment').size.should == @deployments.size
+end
+
+Then /^I should receive details of that deployment as XML$/ do
+  response = last_response
+  response.headers['Content-Type'].should include('application/xml')
+  response.status.should == 200
+  xml_body = Nokogiri::XML(response.body)
+  xml_body.xpath('//deployment').size.should == 1
+  xml_body.xpath('//deployment/name').text.should == @deployment.name
 end

--- a/src/features/step_definitions/deployment_steps.rb
+++ b/src/features/step_definitions/deployment_steps.rb
@@ -12,6 +12,11 @@ Given /^there are some deployments$/ do
   2.times { @deployments << FactoryGirl.create(:deployment, { :pool => Pool.first, :owner => @user }) }
 end
 
+Given /^there are some deployments in that pool$/ do
+  @deployments = []
+  2.times { @deployments << FactoryGirl.create(:deployment, { :pool => @pool, :owner => @user }) }
+end
+
 Given /^there is a deployment$/ do
   @deployment = FactoryGirl.create(:deployment, { :pool => Pool.first, :owner => @user })
 end

--- a/src/features/step_definitions/deployment_steps.rb
+++ b/src/features/step_definitions/deployment_steps.rb
@@ -12,6 +12,15 @@ Given /^there are some deployments$/ do
   2.times { @deployments << FactoryGirl.create(:deployment, { :pool => Pool.first, :owner => @user }) }
 end
 
+Given /^there is a deployment$/ do
+  @deployment = FactoryGirl.create(:deployment, { :pool => Pool.first, :owner => @user })
+end
+
+
+Given /^the specified deployment does not exist in the system$/ do
+  @deployment = FactoryGirl.build(:deployment, { :id => -1 })
+end
+
 When /^I check "([^"]*)" deployment/ do |name|
   deployment = Deployment.find_by_name(name)
   check("deployment_checkbox_#{deployment.id}")

--- a/src/features/step_definitions/deployment_steps.rb
+++ b/src/features/step_definitions/deployment_steps.rb
@@ -7,6 +7,11 @@ Given /^there is a deployment named "([^"]*)" belonging to "([^"]*)" owned by "(
   mock_deltacloud
 end
 
+Given /^there are some deployments$/ do
+  @deployments = []
+  2.times { @deployments << FactoryGirl.create(:deployment, { :pool => Pool.first, :owner => @user }) }
+end
+
 When /^I check "([^"]*)" deployment/ do |name|
   deployment = Deployment.find_by_name(name)
   check("deployment_checkbox_#{deployment.id}")

--- a/src/spec/controllers/api/entrypoint_controller_spec.rb
+++ b/src/spec/controllers/api/entrypoint_controller_spec.rb
@@ -42,6 +42,7 @@ describe Api::EntrypointController do
         api = resp['api']
         api['builds']['href'].should == api_builds_url
         api['catalogs']['href'].should == api_catalogs_url
+        api['deployments']['href'].should == api_deployments_url
         api['images']['href'].should == api_images_url
         api['pools']['href'].should == api_pools_url
         api['pool_families']['href'].should == api_pool_families_url

--- a/src/spec/controllers/pools_controller_spec.rb
+++ b/src/spec/controllers/pools_controller_spec.rb
@@ -199,6 +199,20 @@ describe PoolsController do
           xml.xpath("/pool/catalogs/catalog/@id").text.should == @catalog.id.to_s
         end
       end
+
+      context "for pool with deployments" do
+        before do
+          @pool = FactoryGirl.create :pool_with_deployment
+          @deployment = @pool.deployments[0]
+          get :show, :id => @pool.id
+        end
+
+        it "lists deployments" do
+          xml = Nokogiri::XML(response.body)
+          xml.xpath("/pool/deployments/deployment").size.should == 1
+          xml.xpath("/pool/deployments/deployment/@id").text.should == @deployment.id.to_s
+        end
+      end
     end
 
     describe "#update" do

--- a/src/spec/factories/pool.rb
+++ b/src/spec/factories/pool.rb
@@ -37,4 +37,10 @@ FactoryGirl.define do
     end
   end
 
+  factory :pool_with_deployment, :parent => :pool do |pool|
+    pool.after_create do |pool|
+      Factory :deployment, :pool => pool
+    end
+  end
+
 end

--- a/src/spec/requests/api/deployments_spec.rb
+++ b/src/spec/requests/api/deployments_spec.rb
@@ -50,6 +50,7 @@ describe "Deployments API" do
         # subject.xpath("frontend_realm/@id").text.should == deployment.frontend_realm.id.to_s
         # subject.xpath("frontend_realm/@href").text.should == api_frontend_realm_url(deployment.frontend_realm)
         subject.xpath("uuid").text.should == deployment.uuid
+        subject.xpath("scheduled_for_deletion").text.should == deployment.scheduled_for_deletion.to_s
 
         # TODO implement and test these once it's clear how states should be represented,
         # what date/time format to use etc.:
@@ -58,7 +59,6 @@ describe "Deployments API" do
         # subject.xpath("updated_at").text.should
         # subject.xpath("uptime_1st_instance_running").text.should
         # subject.xpath("global_uptime").text.should
-        # subject.xpath("scheduled_for_deletion").text.should
         # subject.xpath("deployable-xml").text.should
         # subject.xpath("history").text.should
         # subject.xpath("instances/instance").count.should

--- a/src/spec/requests/api/deployments_spec.rb
+++ b/src/spec/requests/api/deployments_spec.rb
@@ -111,4 +111,26 @@ describe "Deployments API" do
     it_behaves_like "responding with XML"
     it_behaves_like "showing deployment details in XML"
   end
+
+  describe "GET /api/pools/:pool_id/deployments" do
+    let!(:unlisted_deployments) do
+      Factory.create(:deployment, {:pool => Pool.first, :owner => @user})
+    end
+    let!(:pool) {
+      Factory.create(:pool)
+    }
+    let!(:deployments) {
+      deployments = []
+      2.times { deployments << Factory.create(:deployment, {:pool => pool, :owner => @user}) }
+      deployments
+    }
+
+    before :each do
+      get "/api/pools/#{pool.id}/deployments", nil, headers
+    end
+
+    it_behaves_like "http OK"
+    it_behaves_like "responding with XML"
+    it_behaves_like "listing deployments in XML"
+  end
 end

--- a/src/spec/requests/api/deployments_spec.rb
+++ b/src/spec/requests/api/deployments_spec.rb
@@ -1,0 +1,62 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+require 'spec_helper'
+
+describe "Deployments API" do
+  shared_examples_for "listing deployments in XML" do
+    subject { Nokogiri::XML(response.body) }
+
+    context "number of deployments" do
+      it { subject.xpath("/deployments/deployment").size.should == deployments.size }
+    end
+
+    context "deployment elements data" do
+      it "is printed correctly" do
+        deployments.each do |deployment|
+          xml_deployment = subject.xpath("/deployments/deployment[@id=\"#{deployment.id}\"]")
+          xml_deployment.size.should == 1
+        end
+      end
+    end
+  end
+
+  let(:headers) { {
+    'HTTP_ACCEPT' => 'application/xml',
+    'CONTENT_TYPE' => 'application/xml'
+  } }
+
+  before :each do
+    @user = FactoryGirl.create(:admin_permission).user
+    login_as(@user)
+  end
+
+  describe "GET /api/deployments" do
+    let!(:deployments) {
+      deployments = []
+      2.times { deployments << Factory.create(:deployment, {:pool => Pool.first, :owner => @user}) }
+      deployments
+    }
+
+    before :each do
+      get '/api/deployments', nil, headers
+    end
+
+    it_behaves_like "http OK"
+    it_behaves_like "responding with XML"
+    it_behaves_like "listing deployments in XML"
+  end
+end

--- a/src/spec/support/shared_examples_for_api.rb
+++ b/src/spec/support/shared_examples_for_api.rb
@@ -17,56 +17,56 @@
 shared_examples_for "http OK" do
   context "response status code" do
     subject { response.status }
-    it { should be_eql(200) }
+    it { should == 200 }
   end
 end
 
 shared_examples_for "http Created" do
   context "response status code" do
     subject { response.status }
-    it { should be_eql(201) }
+    it { should == 201 }
   end
 end
 
 shared_examples_for "http No Content" do
   context "response status code" do
     subject { response.status }
-    it { should be_eql(204) }
+    it { should == 204 }
   end
 end
 
 shared_examples_for "http Bad Request" do
   context "response status code" do
     subject { response.status }
-    it { should be_eql(400) }
+    it { should == 400 }
   end
 end
 
 shared_examples_for "http Forbidden" do
   context "response status code" do
     subject { response.status }
-    it { should be_eql(403) }
+    it { should == 403 }
   end
 end
 
 shared_examples_for "http Not Found" do
   context "response status code" do
     subject { response.status }
-    it { should be_eql(404) }
+    it { should == 404 }
   end
 end
 
 shared_examples_for "http Unprocessable Entity" do
   context "response status code" do
     subject { response.status }
-    it { should be_eql(422) }
+    it { should == 422 }
   end
 end
 
 shared_examples_for "http Internal Server Error" do
   context "response status code" do
     subject { response.status }
-    it { should be_eql(500) }
+    it { should == 500 }
   end
 end
 


### PR DESCRIPTION
This implements read API actions for deployments: listings and show.

Two notes:
- Listing was implemented before Tech Cabal decision that top level listings should be deep and other listings shallow. This double-default nature of #index action will require both code and spec changes and I don't want to delay this pull request, so I'll implement it subsequently.
- # show action provides some basic information. Parts of #show action that require reading CIMI spec or implementation of some other resources are left out for now as well.
