### PR TITLE
API: Time serializers

### DIFF
--- a/src/app/helpers/api_helper.rb
+++ b/src/app/helpers/api_helper.rb
@@ -23,6 +23,30 @@ module ApiHelper
       xmlschema_seconds_string(datetime.strftime('%S.%N'))
   end
 
+  # Serializes into http://www.w3.org/TR/xmlschema-2/#duration
+  # e.g. "P432D14H34M45.023S"
+  # Uses units only upto days, because bigger units (months, years) are
+  # ambiguous). Always prints days, hours, minutes and seconds, even though
+  # the standard allows ommiting.
+  def xmlschema_absolute_duration(total_seconds)
+    seconds_in_day = 86400
+    seconds_in_hour = 3600
+    seconds_in_minute = 60
+
+    days, seconds_minus_days = total_seconds.abs.divmod(seconds_in_day)
+    hours, seconds_minus_hours = seconds_minus_days.divmod(seconds_in_hour)
+    minutes, seconds = seconds_minus_hours.divmod(seconds_in_minute)
+
+    time = ''
+    time << '-' if total_seconds < 0
+    time << 'P' <<
+            '%iD' % days <<
+            'T' <<
+            '%iH' % hours <<
+            '%iM' % minutes <<
+            '%sS' % xmlschema_seconds_string(seconds.to_s)
+  end
+
   private
 
   # Takes a string specifying number of seconds (e.g. "04.2500") and converts

--- a/src/app/helpers/api_helper.rb
+++ b/src/app/helpers/api_helper.rb
@@ -1,0 +1,45 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+module ApiHelper
+
+  # Serializes into http://www.w3.org/TR/xmlschema-2/#dateTime
+  # e.g. "2012-11-05T09:15:53+01:00"
+  def xmlschema_datetime(datetime)
+    datetime.strftime('%FT%H:%M:%%s%:z') %
+      xmlschema_seconds_string(datetime.strftime('%S.%N'))
+  end
+
+  private
+
+  # Takes a string specifying number of seconds (e.g. "04.2500") and converts
+  # the decimal part of the string so that it is valid in XML Schema
+  # datetime/duration representation (e.g. "04.25"). Does not touch the part
+  # that specifies whole seconds (leading zeros are preserved).
+  #
+  # That means:
+  # * if decimal part is zero, it must not be printed at all
+  # * decimal part must not have trailing zeros
+  def xmlschema_seconds_string(seconds_string)
+    fixed_string = seconds_string
+    # if the decimal part is zero(s), it must be removed completely
+    fixed_string.gsub!(/\.0*\Z/, '')
+    # even if decimal part is nonzero, trailing zeros are not allowed
+    fixed_string.gsub!(/0*\Z/, '') if seconds_string.include?('.')
+
+    fixed_string
+  end
+end

--- a/src/spec/helpers/api_helper_spec.rb
+++ b/src/spec/helpers/api_helper_spec.rb
@@ -37,4 +37,49 @@ describe ApiHelper do
     end
   end
 
+  describe "xmlschema_absolute_duration" do
+    subject { api_helper.xmlschema_absolute_duration(duration) }
+
+    context "zero duration" do
+      let(:duration) { 0 }
+
+      it { should == "P0DT0H0M0S" }
+    end
+
+    context "decimal duration" do
+      let(:duration) { 3.14159 }
+
+      it { should == "P0DT0H0M3.14159S" }
+    end
+
+    context "decimal duration with no decimal places" do
+      let(:duration) { 1.0 }
+
+      it "should print 1S, not 1.0S" do
+        subject.should == "P0DT0H0M1S"
+      end
+    end
+
+    context "long duration" do
+      let(:duration) { 456 * 24 * 60 * 60 + # days
+                       8 * 60 * 60 + # hours
+                       57 * 60 + # minutes
+                       3 } # seconds
+
+      it { should == "P456DT8H57M3S" }
+    end
+
+    context "BigDecimal duration" do
+      let(:duration) { BigDecimal.new('0.123123123123123123') }
+
+      it { should == "P0DT0H0M0.123123123123123123S" }
+    end
+
+    context "seconds end with zero, no decimal point" do
+      let(:duration) { BigDecimal.new('10') }
+
+      it { should == "P0DT0H0M10S" }
+    end
+  end
+
 end

--- a/src/spec/helpers/api_helper_spec.rb
+++ b/src/spec/helpers/api_helper_spec.rb
@@ -1,0 +1,40 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+require 'spec_helper'
+
+describe ApiHelper do
+
+  let(:api_helper) { Object.new.extend(ApiHelper) }
+
+  describe "xmlschema_datetime" do
+    subject { api_helper.xmlschema_datetime(datetime) }
+
+    context "simple datetime" do
+      # Aeolus Developer Conference 2012
+      let(:datetime) { DateTime.new(2012, 11, 5, 9, 15, 3, '+1') }
+
+      it { should == "2012-11-05T09:15:03+01:00" }
+    end
+
+    context "datetime with sub-second time information" do
+      let(:datetime) { DateTime.new(2012, 11, 5, 9, 15, 3.456, '+1') }
+
+      it { should == "2012-11-05T09:15:03.456+01:00" }
+    end
+  end
+
+end


### PR DESCRIPTION
Serializers for datetime and duration.

The duration serializer uses units upto days only, because months and years have varying length. 

Days have varying lengths too, but the differences are so small that I hope it does not matter for our purposes. If it should matter, we can always switch to using only units upto hours and still comply with XML Schema standard.

Addresses issue #207.
