### PR TITLE
Changed Tim branch to master

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -25,7 +25,7 @@ gem 'compass-960-plugin', '>= 0.10.4', :require=> 'ninesixty'
 gem 'delayed_job', '~> 2.1.4'
 gem 'paranoia'
 gem 'simple_form', '~> 2.0.3'
-gem 'tim', :git => 'git://github.com/aeolus-incubator/tim.git', :branch => 'model_validations'
+gem 'tim', :git => 'git://github.com/aeolus-incubator/tim.git'
 
 platforms :ruby_18 do
   gem 'fastercsv'

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: git://github.com/aeolus-incubator/tim.git
-  revision: 7f9b2f3a2620e20fa78b81a7e8fe6d43d785dce0
-  branch: model_validations
+  revision: d8c193adf2061445d4c7ec73af53625392543d10
   specs:
     tim (0.1.2)
       haml


### PR DESCRIPTION
Tim validation patch was merged to master branch, so we don't have
to use 'model_validations' branch anymore.
