### PR TITLE
API: Time serializers v2

### DIFF
--- a/src/app/helpers/api_helper.rb
+++ b/src/app/helpers/api_helper.rb
@@ -1,0 +1,45 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+module ApiHelper
+
+  # Serializes into http://www.w3.org/TR/xmlschema-2/#dateTime
+  # e.g. "2012-11-05T09:15:53+01:00"
+  def xmlschema_datetime(datetime)
+    datetime.strftime('%FT%H:%M:%%s%:z') %
+      xmlschema_seconds_string(datetime.strftime('%S.%N'))
+  end
+
+  private
+
+  # Takes a string specifying number of seconds (e.g. "04.2500") and converts
+  # the decimal part of the string so that it is valid in XML Schema
+  # datetime/duration representation (e.g. "04.25"). Does not touch the part
+  # that specifies whole seconds (leading zeros are preserved).
+  #
+  # That means:
+  # * if decimal part is zero, it must not be printed at all
+  # * decimal part must not have trailing zeros
+  def xmlschema_seconds_string(seconds_string)
+    fixed_string = seconds_string
+    # if the decimal part is zero(s), it must be removed completely
+    fixed_string.gsub!(/\.0*\Z/, '')
+    # even if decimal part is nonzero, trailing zeros are not allowed
+    fixed_string.gsub!(/0*\Z/, '') if seconds_string.include?('.')
+
+    fixed_string
+  end
+end

--- a/src/spec/helpers/api_helper_spec.rb
+++ b/src/spec/helpers/api_helper_spec.rb
@@ -1,0 +1,40 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+require 'spec_helper'
+
+describe ApiHelper do
+
+  let(:api_helper) { Object.new.extend(ApiHelper) }
+
+  describe "xmlschema_datetime" do
+    subject { api_helper.xmlschema_datetime(datetime) }
+
+    context "simple datetime" do
+      # Aeolus Developer Conference 2012
+      let(:datetime) { DateTime.new(2012, 11, 5, 9, 15, 3, '+1') }
+
+      it { should == "2012-11-05T09:15:03+01:00" }
+    end
+
+    context "datetime with sub-second time information" do
+      let(:datetime) { DateTime.new(2012, 11, 5, 9, 15, Rational(345, 100), '+1') }
+
+      it { should == "2012-11-05T09:15:03.45+01:00" }
+    end
+  end
+
+end

--- a/src/spec/helpers/api_helper_spec.rb
+++ b/src/spec/helpers/api_helper_spec.rb
@@ -37,4 +37,50 @@ describe ApiHelper do
     end
   end
 
+  describe "xmlschema_absolute_duration" do
+    subject { api_helper.xmlschema_absolute_duration(duration) }
+
+    context "zero duration" do
+      let(:duration) { 0 }
+
+      it { should == "P0DT0H0M0S" }
+    end
+
+    context "Rational duration with decimal places" do
+      let(:duration) { Rational(314159, 100000) }
+
+      it { should == "P0DT0H0M3.14159S" }
+    end
+
+    context "float duration with no value at decimal places" do
+      let(:duration) { 1.0 }
+
+      it "should print 1S, not 1.0S" do
+        subject.should == "P0DT0H0M1S"
+      end
+    end
+
+    context "long duration" do
+      let(:duration) { 456 * 24 * 60 * 60 + # days
+                       8 * 60 * 60 + # hours
+                       57 * 60 + # minutes
+                       3 } # seconds
+
+      it { should == "P456DT8H57M3S" }
+    end
+
+    context "BigDecimal duration" do
+      let(:duration) { BigDecimal.new('0.123123123123123123') }
+      subject { api_helper.xmlschema_absolute_duration(duration, nil) }
+
+      it { should == "P0DT0H0M0.123123123123123123S" }
+    end
+
+    context "seconds end with zero, no decimal point" do
+      let(:duration) { BigDecimal.new('10') }
+
+      it { should == "P0DT0H0M10S" }
+    end
+  end
+
 end


### PR DESCRIPTION
[EDITED]

Fixed spec for Ruby 1.8.

Reading more of the XML Schema standard, durations composed of units upto days are considered totally ordered, so I guess XML Schema doesn't take leap seconds [1] into account. If we want to be less human-readable and avoid any ambiguity due to leap seconds, we can serialize durations using seconds as the only unit. I don't have a strong opinion here but kinda prefer serializing also with days, hours and minutes and not taking leap seconds into account (the way it is implemented now).

Replaces pull request #227, addresses issues #207.

[1] http://en.wikipedia.org/wiki/Leap_second
