### PR TITLE
BaseImages#show, take 2

### DIFF
--- a/src/app/decorators/controllers/tim/base_images_controller_decorator.rb
+++ b/src/app/decorators/controllers/tim/base_images_controller_decorator.rb
@@ -159,7 +159,12 @@ Tim::BaseImagesController.class_eval do
       _targetinfo = {
         :provider_type => provider_type,
         :target_image => target_image,
-        :provider_images => []
+        :provider_images => [],
+        :can_delete => target_image.present? && check_privilege(Privilege::MODIFY, @base_image),
+        :can_build => target_image.nil? && check_privilege(Privilege::MODIFY, @base_image),
+        :delete_url => target_image ? tim.target_image_path(target_image.id) : '',
+        :build_url => tim.target_images_path(:target_image => {:provider_type_id => provider_type.id,
+          :image_version_id => @version.id})
       }
       provider_accounts = accounts_for_provider_type(provider_type, all_prov_accts)
       provider_accounts.each do |provider_account|
@@ -168,7 +173,14 @@ Tim::BaseImagesController.class_eval do
         provider_image_data = {
           :provider_account => provider_account,
           :provider => provider_account.provider,
-          :provider_image => provider_image
+          :provider_image => provider_image,
+          :can_push => target_image && provider_image.nil? && check_privilege(Privilege::MODIFY, @base_image),
+          :can_delete => provider_image && check_privilege(Privilege::MODIFY, @base_image),
+          :push_url => target_image.nil? ? '' : tim.provider_images_path(:provider_image => {
+            :provider_account_id => provider_account.id,
+            :target_image_id => target_image.id
+          }),
+          :delete_url => provider_image ? tim.provider_image_path(provider_image.id) : ''
         }
         _targetinfo[:provider_images] << provider_image_data
       end

--- a/src/app/decorators/controllers/tim/base_images_controller_decorator.rb
+++ b/src/app/decorators/controllers/tim/base_images_controller_decorator.rb
@@ -163,7 +163,8 @@ Tim::BaseImagesController.class_eval do
         :target_image => target_image,
         :provider_images => [],
         :can_delete => target_image.present? && check_privilege(Privilege::MODIFY, @base_image),
-        :can_build => target_image.nil? && check_privilege(Privilege::MODIFY, @base_image),
+        :can_build => !@base_image.imported? && target_image.nil? &&
+          check_privilege(Privilege::MODIFY, @base_image),
         :delete_url => target_image ? tim.target_image_path(target_image.id) : '',
         :build_url => tim.target_images_path(:target_image => {:provider_type_id => provider_type.id,
           :image_version_id => @version.id})
@@ -176,7 +177,8 @@ Tim::BaseImagesController.class_eval do
           :provider_account => provider_account,
           :provider => provider_account.provider,
           :provider_image => provider_image,
-          :can_push => target_image && provider_image.nil? && check_privilege(Privilege::MODIFY, @base_image),
+          :can_push => !@base_image.imported? && target_image && provider_image.nil? &&
+            check_privilege(Privilege::MODIFY, @base_image),
           :can_delete => provider_image && check_privilege(Privilege::MODIFY, @base_image),
           :push_url => target_image.nil? ? '' : tim.provider_images_path(:provider_image => {
             :provider_account_id => provider_account.id,

--- a/src/app/decorators/controllers/tim/base_images_controller_decorator.rb
+++ b/src/app/decorators/controllers/tim/base_images_controller_decorator.rb
@@ -149,7 +149,9 @@ Tim::BaseImagesController.class_eval do
     @targets = []
 
     # Preload up some data
-    all_prov_accts = @base_image.pool_family.provider_accounts.includes(:provider => :provider_type)
+    all_prov_accts = @base_image.pool_family.provider_accounts.
+      list_for_user(current_session, current_user, Privilege::USE).
+      includes(:provider => :provider_type)
     provider_types = available_provider_types_for_base_image(@base_image)
     target_images = @version.target_images(:include => :provider_images)
 

--- a/src/app/decorators/controllers/tim/base_images_controller_decorator.rb
+++ b/src/app/decorators/controllers/tim/base_images_controller_decorator.rb
@@ -137,8 +137,8 @@ Tim::BaseImagesController.class_eval do
     @versions = @base_image.image_versions.order('created_at DESC')
     @latest_version = @versions.first # because we sorted above
     # @version is the specific image version we're viewing
-    @version = if params[:version]
-      @versions.find{|v| v.id == params[:version]} || @latest_version
+    @version = if params[:build]
+      @versions.find{|v| v.uuid == params[:build]} || @latest_version
     else
       @latest_version
     end

--- a/src/app/decorators/controllers/tim/base_images_controller_decorator.rb
+++ b/src/app/decorators/controllers/tim/base_images_controller_decorator.rb
@@ -24,6 +24,8 @@ Tim::BaseImagesController.class_eval do
 
   before_filter :set_tabs_and_headers, :only => [:index]
   before_filter :set_new_form_variables, :only => [:new]
+  before_filter :set_image_versions, :only => :show
+  before_filter :set_targets, :only => :show
 
   # FIXME: whole create method is overriden just because of
   # setting flash error and new_form_variables if creation fails
@@ -130,4 +132,72 @@ Tim::BaseImagesController.class_eval do
       )]
     end
   end
+
+  def set_image_versions
+    @versions = @base_image.image_versions.order('created_at DESC')
+    @latest_version = @versions.first # because we sorted above
+    # @version is the specific image version we're viewing
+    @version = if params[:version]
+      @versions.find{|v| v.id == params[:version]} || @latest_version
+    else
+      @latest_version
+    end
+  end
+
+  def set_targets
+    return [] unless @version # Otherwise, there's no point
+    @targets = []
+
+    # Preload up some data
+    all_prov_accts = @base_image.pool_family.provider_accounts.includes(:provider => :provider_type)
+    provider_types = available_provider_types_for_base_image(@base_image)
+    target_images = @version.target_images(:include => :provider_images)
+
+    # Run over all provider types
+    provider_types.each do |provider_type|
+      target_image = target_images.select{|ti| ti.provider_type_id == provider_type.id}.first
+      _targetinfo = {
+        :provider_type => provider_type,
+        :target_image => target_image,
+        :provider_images => []
+      }
+      provider_accounts = accounts_for_provider_type(provider_type, all_prov_accts)
+      provider_accounts.each do |provider_account|
+        provider_image = target_image.provider_images.select{|pi|
+          pi.factory_provider_account_id == provider_account.id}.first if target_image.present?
+        provider_image_data = {
+          :provider_account => provider_account,
+          :provider => provider_account.provider,
+          :provider_image => provider_image
+        }
+        _targetinfo[:provider_images] << provider_image_data
+      end
+      @targets << _targetinfo
+    end
+  end
+
+  private
+
+  # We need this above. For a base image, find all _available_ ProviderTypes,
+  # whether or not we have built for it.
+  # This was too messy to do above, but feels too arcane to put in the BaseImage model,
+  # especially since it's so tangentially related to BaseImages at all.
+  def available_provider_types_for_base_image(base_image)
+    all_types = []
+    # Eager load all the data we'll need, rather than doing a bunch of one-off queries:
+    prov_accts = @base_image.pool_family.provider_accounts.includes(:provider => :provider_type)
+    prov_accts.each do |provider_account|
+      type = provider_account.provider.provider_type
+      all_types << type unless all_types.include?(type)
+    end
+    all_types
+  end
+
+  # Another weird one-off with no good home...
+  # Find all provider accounts (in a given set, though we could look it up)
+  # that have a given provider type.
+  def accounts_for_provider_type(provider_type, provider_accounts)
+    provider_accounts.select{|pa| pa.provider.provider_type_id == provider_type.id}
+  end
+
 end

--- a/src/app/decorators/models/tim/base_image_decorator.rb
+++ b/src/app/decorators/models/tim/base_image_decorator.rb
@@ -53,8 +53,7 @@ Tim::BaseImage.class_eval do
   end
 
   def imported?
-    # TODO: implement this
-    false
+    !!import
   end
 
   def last_built_image_version

--- a/src/app/decorators/models/tim/provider_image_decorator.rb
+++ b/src/app/decorators/models/tim/provider_image_decorator.rb
@@ -22,7 +22,8 @@ Tim::ProviderImage.class_eval do
 
   before_create :set_credentials
 
-  STATUS_COMPLETE = 'COMPLETE'
+  STATUS_COMPLETE = 'COMPLETED'
+  STATUS_IMPORTED = 'IMPORTED'
 
   def self.find_by_images(images)
     Tim::ProviderImage.joins(:target_image => :image_version).
@@ -60,6 +61,15 @@ Tim::ProviderImage.class_eval do
     end
 
     true
+  end
+
+  # This is a misnomer -- a TargetImage is built, and a ProviderImage is pushed.
+  def built?
+    target_image.built?
+  end
+
+  def pushed?
+    status == STATUS_COMPLETE || imported?
   end
 
   private

--- a/src/app/decorators/models/tim/target_image_decorator.rb
+++ b/src/app/decorators/models/tim/target_image_decorator.rb
@@ -42,6 +42,10 @@ Tim::TargetImage.class_eval do
     image_version.base_image
   end
 
+  def built?
+    status == 'COMPLETED' || imported?
+  end
+
   private
 
   def set_target

--- a/src/app/helpers/tim/base_images_helper.rb
+++ b/src/app/helpers/tim/base_images_helper.rb
@@ -1,5 +1,5 @@
 #
-#   Copyright 2011 Red Hat, Inc.
+#   Copyright 2012 Red Hat, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -17,5 +17,18 @@
 # Filters added to this controller apply to all controllers in the application.
 # Likewise, all the methods added will be available for all controllers.
 
-module ImagesHelper
+module Tim::BaseImagesHelper
+  def image_name(base_image)
+    base_image.imported? ? "#{base_image.name} (Imported)" : base_image.name
+  end
+
+  def options_for_build_select(builds, selected, latest)
+      options_for_select(builds.map do |b|
+        label = Time.at(b.created_at.to_f).to_s
+        label += " (#{t'images.show.latest'})" if b.uuid == latest
+        [label, b.uuid]
+      end, selected ? selected.uuid : nil)
+  end
+
+
 end

--- a/src/app/helpers/tim/base_images_helper.rb
+++ b/src/app/helpers/tim/base_images_helper.rb
@@ -19,7 +19,8 @@
 
 module Tim::BaseImagesHelper
   def image_name(base_image)
-    base_image.imported? ? "#{base_image.name} (Imported)" : base_image.name
+    base_image.imported? ? "#{t('tim.base_images.imported_image_with_name',
+      :image_name => base_image.name)}" : base_image.name
   end
 
   def options_for_build_select(builds, selected, latest)

--- a/src/app/views/tim/base_images/_status.html.mustache
+++ b/src/app/views/tim/base_images/_status.html.mustache
@@ -1,0 +1,36 @@
+{{#images}}
+  <li class="clearfix">
+    <dl>
+      <dt>
+        <div class="build-actions">
+          <h3>{{provider_type.name}}</h3>
+        </div>
+      </dt>
+      <dd>
+        <table class="light_table">
+          <thead>
+            <tr><th>
+              <strong><%= t('tim.base_images.show.account') %></strong>
+            </th>
+            <th>
+              <%= t('tim.base_images.show.provider') %>
+            </th>
+            <th>
+              <%= t('tim.base_images.show.providers_image_id') %>
+            </th>
+            <th class="image_controls"></th>
+          </tr></thead>
+          <tbody>
+          {{#provider_images}}
+            <tr>
+              <td><strong> {{provider_account.name}} </strong></td>
+              <td class="light">{{provider.name }} </td>
+              <td class="light">{{provider_image.external_image_id}}</td>
+            </tr>
+          {{/provider_images}}
+          </tbody>
+        </table>
+      </dd>
+    </dl>
+  </li>
+{{/images}}

--- a/src/app/views/tim/base_images/_status.html.mustache
+++ b/src/app/views/tim/base_images/_status.html.mustache
@@ -4,6 +4,20 @@
       <dt>
         <div class="build-actions">
           <h3>{{provider_type.name}}</h3>
+          {{#target_image.present?}}
+            {{#can_delete}}
+              <%= button_to(t('tim.base_images.show.delete'),
+                '{{delete_url}}',
+                :method => :delete) %>
+            {{/can_delete}}
+          {{/target_image.present?}}
+          {{^target_image.present?}}
+            {{#can_build}}
+              <%= button_to(t('tim.base_images.show.build'),
+                '{{build_url}}',
+                :method => :post) %>
+            {{/can_build}}
+          {{/target_image.present?}}
         </div>
       </dt>
       <dd>
@@ -26,6 +40,22 @@
               <td><strong> {{provider_account.name}} </strong></td>
               <td class="light">{{provider.name }} </td>
               <td class="light">{{provider_image.external_image_id}}</td>
+              <td class="light">
+              {{#provider_image.pushed?}}
+                {{#can_delete}}
+                <%= button_to(t('tim.base_images.show.delete'),
+                  '{{delete_url}}',
+                  :method => :delete) %>
+                {{/can_delete}}
+              {{/provider_image.pushed?}}
+              {{^provider_image.pushed?}}
+                {{#can_push}}
+                  <%= button_to(t('tim.base_images.show.push'),
+                    '{{push_url}}',
+                    :method => :post) %>
+                {{/can_push}}
+              {{/provider_image.pushed?}}
+              </td>
             </tr>
           {{/provider_images}}
           </tbody>

--- a/src/app/views/tim/base_images/show.html.haml
+++ b/src/app/views/tim/base_images/show.html.haml
@@ -33,7 +33,7 @@
       - if @versions.any?
         %span= t'tim.base_images.show.view_build'
         - if user_can_build
-          = form_tag image_path(@base_image.id), :method => :get do
+          = form_tag base_image_path(@base_image.id), :method => :get do
             = select_tag :build, options_for_build_select(@versions, @version, @latest_image_version)
             = submit_tag t('tim.base_images.show.select_build'), :id => 'select_build_button'
     %h2= t('tim.base_images.show.provider_images')

--- a/src/app/views/tim/base_images/show.html.haml
+++ b/src/app/views/tim/base_images/show.html.haml
@@ -9,7 +9,7 @@
       .button-group
         = link_to t('tim.base_images.show.new_deployable_from_image'), main_app.new_deployable_path(:create_from_image => @base_image.id), :class => 'button'
         - unless @base_image.imported?
-          = link_to t('tim.base_images.show.template_xml'), main_app.template_image_path(@base_image.uuid), :class => 'button' # FIXME: This needs to be reimplemented
+          = link_to t('tim.base_images.show.template_xml'), template_path(@base_image.uuid), :class => 'button' # FIXME: This needs to be reimplemented
         = button_to t("delete"), base_image_path(@base_image.id), :method => 'delete', :confirm => t('general.delete_confirmation'), :class => 'button danger', :id => 'delete'
   %h1.no-icon= image_name(@base_image)
 

--- a/src/app/views/tim/base_images/show.html.haml
+++ b/src/app/views/tim/base_images/show.html.haml
@@ -36,6 +36,10 @@
           = form_tag base_image_path(@base_image.id), :method => :get do
             = select_tag :build, options_for_build_select(@versions, @version, @latest_image_version)
             = submit_tag t('tim.base_images.show.select_build'), :id => 'select_build_button'
+      - if user_can_build && !@base_image.imported?
+        |
+        = form_tag build_all_base_image_path(@base_image.id), :method => :post do
+          = submit_tag t('tim.base_images.show.build_all'), :id => 'build_all_button'
     %h2= t('tim.base_images.show.provider_images')
 
   .content

--- a/src/app/views/tim/base_images/show.html.haml
+++ b/src/app/views/tim/base_images/show.html.haml
@@ -1,0 +1,54 @@
+= render :partial => 'layouts/admin_nav'
+
+%header.page-header
+  .obj_actions
+    .return_to
+      =t'return_to'
+      = link_to t('tim.base_images.index.images'), base_images_path
+    - if check_privilege(Privilege::MODIFY, @base_image)
+      .button-group
+        = link_to t('tim.base_images.show.new_deployable_from_image'), main_app.new_deployable_path(:create_from_image => @base_image.id), :class => 'button'
+        - unless @base_image.imported?
+          = link_to t('tim.base_images.show.template_xml'), main_app.template_image_path(@base_image.uuid), :class => 'button' # FIXME: This needs to be reimplemented
+        = button_to t("delete"), base_image_path(@base_image.id), :method => 'delete', :confirm => t('general.delete_confirmation'), :class => 'button danger', :id => 'delete'
+  %h1.no-icon= image_name(@base_image)
+
+- user_can_build = (check_privilege(Privilege::MODIFY, @base_image))
+%section.content-section
+  %header
+    %h2=t'properties'
+  .content
+    %table.properties_table
+      %tbody
+        %tr
+          %td= t('tim.base_images.environment')
+          %td= @base_image.pool_family.name
+        %tr
+          %td= t('tim.base_images.show.image_id')
+          %td= @base_image.uuid
+
+%section.content-section
+  %header
+    .section-controls
+      - if @versions.any?
+        %span= t'tim.base_images.show.view_build'
+        - if user_can_build
+          = form_tag image_path(@base_image.id), :method => :get do
+            = select_tag :build, options_for_build_select(@versions, @version, @latest_image_version)
+            = submit_tag t('tim.base_images.show.select_build'), :id => 'select_build_button'
+    %h2= t('tim.base_images.show.provider_images')
+
+  .content
+    %ul.image_builds
+      = render :partial => 'status', :mustache => {:images => @targets}
+
+:javascript
+  $(document).ready(function(){
+    $("#select_build_button").hide();
+    $("#build").change(function() {
+      $("#select_build_button").click();
+    });
+  });
+
+%script#imageStatusTemplate{ :type => 'text/html' }
+  = render :partial => 'status'

--- a/src/config/locales/en.yml
+++ b/src/config/locales/en.yml
@@ -1598,4 +1598,4 @@ en:
         make_deployable: Automatically make "%{name}" Deployable.
         edit_xml: View and Edit Template XML
         save_template: Save Image Template
-      imported_parenthetical: "(Imported)"
+      imported_image_with_name: "%{image_name} (Imported)"

--- a/src/config/locales/en.yml
+++ b/src/config/locales/en.yml
@@ -1598,3 +1598,4 @@ en:
         make_deployable: Automatically make "%{name}" Deployable.
         edit_xml: View and Edit Template XML
         save_template: Save Image Template
+      imported_parenthetical: "(Imported)"

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -78,6 +78,9 @@ Conductor::Application.routes.draw do
         post 'edit_xml'
         post 'overview'
       end
+      member do
+        post 'build_all'
+      end
     end
   end
 

--- a/src/public/javascripts/backbone/routers.js
+++ b/src/public/javascripts/backbone/routers.js
@@ -100,9 +100,9 @@ Conductor.Routers.Deployables = Backbone.Router.extend({
 
 Conductor.Routers.Images = Backbone.Router.extend({
   routes: {
-    'images:query': 'index',
+    'tim/base_images:query': 'index',
     'pool_families': 'index',
-    'images/:id': 'show',
+    'tim/base_images/:id': 'show',
     'pool_families/:id': 'environmentImageList'
   },
 


### PR DESCRIPTION
This is an update to https://github.com/aeolusproject/conductor/pull/235
- The whitespace errors Jan found should be fixed
- `list_for_user` is used to filter provider accounts displayed
- I corrected the COMPLETE/COMPLETED constant value
- Imported images cannot be build/pushed
- I implemented a `build_all` method in the BaseImagesController. That's not 100% relevant to listing images, but as Jan points out, it's quite helpful to testing.
- As a bonus, I found and fixed a bug preventing users from selecting anything other than the most recent ImageVersion. I squashed it into the commit the bug was introduced in, so there's no trace that it ever happened :angel: 

The issue Jan noted with calling `imported?` on a ProviderImage and working our way up a few ancestors to check BaseImage's status is is ultimate a Tim bug/RFE, IMHO. I thought about redeclaring the method locally, but I'd rather just get it fixed in Tim.
