### PR TITLE
API: Make time helpers more defensive

### DIFF
--- a/src/app/helpers/api_helper.rb
+++ b/src/app/helpers/api_helper.rb
@@ -18,7 +18,10 @@ module ApiHelper
 
   # Serializes into http://www.w3.org/TR/xmlschema-2/#dateTime
   # e.g. "2012-11-05T09:15:53+01:00"
-  def xmlschema_datetime(datetime)
+  def xmlschema_datetime(datetime_param)
+    return '' if datetime_param.nil?
+    datetime = datetime_param.to_datetime
+
     datetime.strftime('%FT%H:%M:%%s%:z') %
       xmlschema_seconds_string(datetime.strftime('%S.%N'))
   end
@@ -33,6 +36,8 @@ module ApiHelper
   # set to nil when using BigDecimal total_seconds, then the precision is
   # unlimited (will print the BigDecimal precisely).
   def xmlschema_absolute_duration(total_seconds, max_decimal_places = 9)
+    return '' if total_seconds.nil?
+
     seconds_in_day = 86400
     seconds_in_hour = 3600
     seconds_in_minute = 60

--- a/src/spec/helpers/api_helper_spec.rb
+++ b/src/spec/helpers/api_helper_spec.rb
@@ -35,6 +35,12 @@ describe ApiHelper do
 
       it { should == "2012-11-05T09:15:03.45+01:00" }
     end
+
+    context "nil datetime" do
+      let(:datetime) { nil }
+
+      it { should == "" }
+    end
   end
 
   describe "xmlschema_absolute_duration" do
@@ -80,6 +86,12 @@ describe ApiHelper do
       let(:duration) { BigDecimal.new('10') }
 
       it { should == "P0DT0H0M10S" }
+    end
+
+    context "nil duration" do
+      let(:duration) { nil }
+
+      it { should == "" }
     end
   end
 


### PR DESCRIPTION
Check for nils, convert datetime parameter to the true datetime (to prevent
errors when using ActiveSupport::TimeWithZone on Ruby 1.8 [1]).

[1] https://github.com/aeolusproject/conductor/pull/273#issuecomment-11516852
