### PR TITLE
API: Instances index, show, and entrypoint v3

### DIFF
--- a/src/app/controllers/instances_controller.rb
+++ b/src/app/controllers/instances_controller.rb
@@ -30,6 +30,7 @@ class InstancesController < ApplicationController
       format.html
       format.js { render :partial => 'list' }
       format.json { render :json => @instances.map{ |instance| view_context.instance_for_mustache(instance) } }
+      format.xml { render :partial => 'list.xml' }
     end
   end
 
@@ -55,6 +56,7 @@ class InstancesController < ApplicationController
         render :partial => @details_tab[:view] and return
       end
       format.json { render :json => @instance }
+      format.xml { render :show, :locals => { :instance => @instance } }
     end
   end
 

--- a/src/app/controllers/instances_controller.rb
+++ b/src/app/controllers/instances_controller.rb
@@ -30,7 +30,7 @@ class InstancesController < ApplicationController
       format.html
       format.js { render :partial => 'list' }
       format.json { render :json => @instances.map{ |instance| view_context.instance_for_mustache(instance) } }
-      format.xml { render :partial => 'list.xml' }
+      format.xml { @deployment = @instances.first.deployment if params[:deployment_id] }
     end
   end
 

--- a/src/app/controllers/instances_controller.rb
+++ b/src/app/controllers/instances_controller.rb
@@ -56,7 +56,7 @@ class InstancesController < ApplicationController
         render :partial => @details_tab[:view] and return
       end
       format.json { render :json => @instance }
-      format.xml { render :show, :locals => { :instance => @instance } }
+      format.xml
     end
   end
 

--- a/src/app/helpers/instances_helper.rb
+++ b/src/app/helpers/instances_helper.rb
@@ -29,4 +29,12 @@ module InstancesHelper
       {:name => t('instances.list.table.owner'), :sortable => false }
     ]
   end
+
+  def api_instances_collection_href(deployment = nil)
+    if deployment
+      api_deployment_instances_url(deployment)
+    else
+      api_instances_url
+    end
+  end
 end

--- a/src/app/views/api/entrypoint/index.xml.haml
+++ b/src/app/views/api/entrypoint/index.xml.haml
@@ -4,6 +4,7 @@
   %catalogs{:href => api_catalogs_url}
   %deployments{:href => api_deployments_url}
   %images{:href => api_images_url}
+  %instances{:href => api_instances_url}
   %pools{:href => api_pools_url}
   %pool_families{:href => api_pool_families_url}
   %providers{:href => api_providers_url}

--- a/src/app/views/instances/_detail.xml.haml
+++ b/src/app/views/instances/_detail.xml.haml
@@ -1,19 +1,19 @@
 !!! XML
 %instance{:id => instance.id, :href => api_instance_url(instance)}
-  %name= instance.name
-  %external_key= instance.external_key
-  %hardware_profile{:id => instance.hardware_profile.id, :href=> api_hardware_profile_url(instance.hardware_profile)}
-  %pool{:id => instance.pool.id, :href=> api_pool_url(instance.pool)}
-  %deployment{:id => instance.deployment.id, :href=> api_deployment_url(instance.deployment)}
-  %provider_account{:id => instance.provider_account.id, :href=> api_provider_account_url(instance.provider_account)}
-  %public_addresses= instance.public_addresses
-  %private_addresses= instance.private_addresses
-  %created_at= xmlschema_datetime(instance.created_at)
-  %updated_at= xmlschema_datetime(instance.updated_at)
-  - # TODO add deployment
-  %assembly_xml= raw instance.assembly_xml
-  %instance_config_xml= raw instance.instance_config_xml
-  %user_data= instance.user_data
-  - if instance.instance_key
-    %ssh_key{:href => key_instance_url(instance.instance_key)}
-    %ssh_key_name= instance.instance_key.name
+  - unless shallow
+    %name= instance.name
+    %external_key= instance.external_key
+    %hardware_profile{:id => instance.hardware_profile.id, :href=> api_hardware_profile_url(instance.hardware_profile)}
+    %pool{:id => instance.pool.id, :href=> api_pool_url(instance.pool)}
+    %deployment{:id => instance.deployment.id, :href=> api_deployment_url(instance.deployment)}
+    %provider_account{:id => instance.provider_account.id, :href=> api_provider_account_url(instance.provider_account)}
+    %public_addresses= instance.public_addresses
+    %private_addresses= instance.private_addresses
+    %created_at= xmlschema_datetime(instance.created_at)
+    %updated_at= xmlschema_datetime(instance.updated_at)
+    %assembly_xml= raw instance.assembly_xml
+    %instance_config_xml= raw instance.instance_config_xml
+    %user_data= instance.user_data
+    - if instance.instance_key
+      %ssh_key{:href => key_instance_url(instance.instance_key)}
+      %ssh_key_name= instance.instance_key.name

--- a/src/app/views/instances/_detail.xml.haml
+++ b/src/app/views/instances/_detail.xml.haml
@@ -1,0 +1,19 @@
+!!! XML
+%instance{:id => instance.id, :href => api_instance_url(instance)}
+  %name= instance.name
+  %external_key= instance.external_key
+  %hardware_profile{:id => instance.hardware_profile.id, :href=> api_hardware_profile_url(instance.hardware_profile)}
+  %pool{:id => instance.pool.id, :href=> api_pool_url(instance.pool)}
+  %deployment{:id => instance.deployment.id, :href=> api_deployment_url(instance.deployment)}
+  %provider_account{:id => instance.provider_account.id, :href=> api_provider_account_url(instance.provider_account)}
+  %public_addresses= instance.public_addresses
+  %private_addresses= instance.private_addresses
+  %created_at= xmlschema_datetime(instance.created_at)
+  %updated_at= xmlschema_datetime(instance.updated_at)
+  - # TODO add deployment
+  %assembly_xml= raw instance.assembly_xml
+  %instance_config_xml= raw instance.instance_config_xml
+  %user_data= instance.user_data
+  - if instance.instance_key
+    %ssh_key{:href => key_instance_url(instance.instance_key)}
+    %ssh_key_name= instance.instance_key.name

--- a/src/app/views/instances/_list.xml.haml
+++ b/src/app/views/instances/_list.xml.haml
@@ -1,0 +1,4 @@
+!!! XML
+%instances
+  - @instances.each do |instance|
+    %instance{:id => instance.id, :href => api_instance_url(instance)}

--- a/src/app/views/instances/_list.xml.haml
+++ b/src/app/views/instances/_list.xml.haml
@@ -1,4 +1,4 @@
 !!! XML
-%instances
+%instances{ :href => instances_href }
   - @instances.each do |instance|
-    %instance{:id => instance.id, :href => api_instance_url(instance)}
+    =render '/instances/detail', :instance => instance, :shallow => shallow

--- a/src/app/views/instances/index.xml.haml
+++ b/src/app/views/instances/index.xml.haml
@@ -1,0 +1,3 @@
+!!! XML
+=render 'list', :instances => @instances, :shallow => false,
+                :instances_href => api_instances_collection_href(@deployment)

--- a/src/app/views/instances/show.xml.haml
+++ b/src/app/views/instances/show.xml.haml
@@ -1,0 +1,2 @@
+!!! XML
+=render 'detail', :instance => instance

--- a/src/app/views/instances/show.xml.haml
+++ b/src/app/views/instances/show.xml.haml
@@ -1,2 +1,2 @@
 !!! XML
-=render 'detail', :instance => instance
+=render 'detail', :instance => instance, :shallow => false

--- a/src/app/views/instances/show.xml.haml
+++ b/src/app/views/instances/show.xml.haml
@@ -1,2 +1,2 @@
 !!! XML
-=render 'detail', :instance => instance, :shallow => false
+=render 'detail', :instance => @instance, :shallow => false

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -322,6 +322,7 @@ Conductor::Application.routes.draw do
     resources :deployments, :only => [:index, :show]
     resources :deployables, :only => [:index]
     resources :provider_realms, :only => [:index, :show]
+    resources :instances, :only => [:index, :show]
   end
 
   #match 'matching_profiles', :to => '/hardware_profiles/matching_profiles/:hardware_profile_id/provider/:provider_id', :controller => 'hardware_profiles', :action => 'matching_profiles', :conditions => { :method => :get }, :as =>'matching_profiles'

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -319,7 +319,9 @@ Conductor::Application.routes.draw do
     resources :catalogs, :only => [:index, :show, :create, :update, :destroy] do
       resources :deployables, :only => [:index]
     end
-    resources :deployments, :only => [:index, :show]
+    resources :deployments, :only => [:index, :show] do
+      resources :instances, :only => [:index]
+    end
     resources :deployables, :only => [:index]
     resources :provider_realms, :only => [:index, :show]
     resources :instances, :only => [:index, :show]

--- a/src/spec/controllers/api/entrypoint_controller_spec.rb
+++ b/src/spec/controllers/api/entrypoint_controller_spec.rb
@@ -44,6 +44,7 @@ describe Api::EntrypointController do
         api['catalogs']['href'].should == api_catalogs_url
         api['deployments']['href'].should == api_deployments_url
         api['images']['href'].should == api_images_url
+        api['instances']['href'].should == api_instances_url
         api['pools']['href'].should == api_pools_url
         api['pool_families']['href'].should == api_pool_families_url
         api['providers']['href'].should == api_providers_url

--- a/src/spec/factories/instance.rb
+++ b/src/spec/factories/instance.rb
@@ -23,7 +23,12 @@ FactoryGirl.define do
     association :provider_account, :factory => :mock_provider_account
     association :pool, :factory => :pool
     association :owner, :factory => :user
-    state "running"
+    association :deployment, :factory => :deployment
+    state Instance::STATE_RUNNING
+    public_addresses "server1.example.org"
+    private_addresses "0.0.0.1"
+    user_data "test-user-data"
+
     after_build do |instance|
       deployment = Factory.build :deployment
       assembly = deployment.deployable_xml.assemblies[0]
@@ -38,7 +43,7 @@ FactoryGirl.define do
   end
 
   factory :mock_running_instance, :parent => :instance do
-    instance_key { |k| k.association(:mock_instance_key)}
+    association :instance_key, :factory => :mock_instance_key
   end
 
   factory :mock_pending_instance, :parent => :instance do

--- a/src/spec/requests/api/instances_spec.rb
+++ b/src/spec/requests/api/instances_spec.rb
@@ -30,6 +30,50 @@ describe "Instances" do
       @instance.instance_key.should_not be_nil
     end
 
+    def check_instance_xml(xml_instance, instance)
+      api_helper = Object.new.extend(ApiHelper)
+
+      xml_instance.xpath("@id").text.should == instance.id.to_s
+      xml_instance.xpath("@href").text.should == api_instance_url(instance)
+      xml_instance.xpath("name").text.should == instance.name
+      xml_instance.xpath("external_key").text.should == instance.external_key
+      #xml_instance.xpath("state").text.should == instance.state
+      xml_instance.xpath("hardware_profile[@id='#{instance.hardware_profile.id}']/@href").
+        text.should == api_hardware_profile_url(instance.hardware_profile)
+      # TODO: users api endpoint
+      #xml_instance.xpath("owner_id").text.should == instance.owner_id.to_s
+      xml_instance.xpath("pool[@id='#{instance.pool.id}']/@href").
+        text.should == api_pool_url(instance.pool)
+      xml_instance.xpath("deployment[@id='#{instance.deployment.id}']/@href").
+        text.should == api_deployment_url(instance.deployment)
+      xml_instance.xpath("provider_account[@id='#{instance.provider_account.id}']/@href").
+        text.should == api_provider_account_url(instance.provider_account)
+      xml_instance.xpath("public_addresses").text.should == instance.public_addresses
+      xml_instance.xpath("private_addresses").text.should == instance.private_addresses
+      xml_instance.xpath("created_at").
+        text.should == api_helper.xmlschema_datetime(instance.created_at)
+      xml_instance.xpath("updated_at").
+        text.should == api_helper.xmlschema_datetime(instance.updated_at)
+      xml_instance.xpath("assembly_xml").inner_html.
+        should== instance.assembly_xml.to_s
+      xml_instance.xpath("instance_config_xml").inner_html.
+        should == instance.instance_config_xml.to_s
+      # TODO: point to resource url after Tim integration
+      #xml_instance.xpath("image_uuid").text.should == instance.image_uuid.to_s
+      #xml_instance.xpath("image_build_uuid").text.should == instance.image_build_uuid.to_s
+      #xml_instance.xpath("provider_image_uuid").text.should == instance.provider_image_uuid.to_s
+      #xml_instance.xpath("provider_instance_id").text.should == instance.provider_instance_id.to_s
+      xml_instance.xpath("user_data").text.should == instance.user_data.to_s
+      xml_instance.xpath("ssh_key/@href").
+        text.should == key_instance_url(instance.instance_key)
+      xml_instance.xpath("ssh_key_name").text.should == instance.instance_key.name
+      # TODO events api endpoint
+      #xml_instance.xpath("history/entry").size.should > 0
+      #xml_instance.xpath("history/entry/time").
+      #  text.should == instance.events.first.event_time.strftime("%Y-%m-%d %H:%M:%S UTC")
+      #xml_instance.xpath("history/entry/message").text.should == instance.events.first.summary
+    end
+
     describe "#index" do
 
       it "get index" do
@@ -41,9 +85,30 @@ describe "Instances" do
         xml = Nokogiri::XML(response.body)
 
         xml.xpath("/instances/instance").size.should > 0
-        xml.xpath("/instances/instance[@id='#{@instance.id}']/@href").
-          text.should == api_instance_url(@instance.id)
+        xml.xpath("/instances/instance").size.should == Instance.all.size
+        xml.xpath("/instances/@href").text.should == api_instances_url
+        Instance.all.each do |instance|
+          check_instance_xml(xml.xpath("/instances/instance[@id='#{instance.id}']"), instance)
+        end
       end
+
+      it "get collection of instances from deployment" do
+        Instance.all.size.should_not == @instance.deployment.instances.size
+
+        get "/api/deployments/#{@instance.deployment.id}/instances", nil, headers
+        response.should be_success
+        response.should have_content_type("application/xml")
+        response.body.should be_xml
+        xml = Nokogiri::XML(response.body)
+
+        xml.xpath("/instances/instance").size.should > 0
+        xml.xpath("/instances/instance").size.should == @instance.deployment.instances.size
+        xml.xpath("/instances/@href").text.should == api_deployment_instances_url(@instance.deployment)
+        @instance.deployment.instances.each do |instance|
+          check_instance_xml(xml.xpath("/instances/instance[@id='#{instance.id}']"), instance)
+        end
+      end
+
     end
 
     describe "#show" do
@@ -54,44 +119,7 @@ describe "Instances" do
         response.should have_content_type("application/xml")
         response.body.should be_xml
         xml = Nokogiri::XML(response.body)
-        api_helper = Object.new.extend(ApiHelper)
-
-        xml.xpath("/instance/@id").text.should == @instance.id.to_s
-        xml.xpath("/instance/@href").text.should == api_instance_url(@instance)
-        xml.xpath("/instance/name").text.should == @instance.name
-        xml.xpath("/instance/external_key").text.should == @instance.external_key
-        #xml.xpath("/instance/state").text.should == @instance.state
-        xml.xpath("/instance/hardware_profile[@id='#{@instance.hardware_profile.id}']/@href").
-          text.should == api_hardware_profile_url(@instance.hardware_profile)
-        #xml.xpath("/instance/owner_id").text.should == @instance.owner_id.to_s
-        xml.xpath("/instance/pool[@id='#{@instance.pool.id}']/@href").
-          text.should == api_pool_url(@instance.pool)
-        xml.xpath("/instance/deployment[@id='#{@instance.deployment.id}']/@href").
-          text.should == api_deployment_url(@instance.deployment)
-        xml.xpath("/instance/provider_account[@id='#{@instance.provider_account.id}']/@href").
-          text.should == api_provider_account_url(@instance.provider_account)
-        xml.xpath("/instance/public_addresses").text.should == @instance.public_addresses
-        xml.xpath("/instance/private_addresses").text.should == @instance.private_addresses
-        xml.xpath("/instance/created_at").
-          text.should == api_helper.xmlschema_datetime(@instance.created_at)
-        xml.xpath("/instance/updated_at").
-          text.should == api_helper.xmlschema_datetime(@instance.updated_at)
-        xml.xpath("/instance/assembly_xml").inner_html.
-          should== @instance.assembly_xml.to_s
-        xml.xpath("/instance/instance_config_xml").inner_html.
-          should == @instance.instance_config_xml.to_s
-        #xml.xpath("/instance/image_uuid").text.should == @instance.image_uuid.to_s
-        #xml.xpath("/instance/image_build_uuid").text.should == @instance.image_build_uuid.to_s
-        #xml.xpath("/instance/provider_image_uuid").text.should == @instance.provider_image_uuid.to_s
-        #xml.xpath("/instance/provider_instance_id").text.should == @instance.provider_instance_id.to_s
-        xml.xpath("/instance/user_data").text.should == @instance.user_data.to_s
-        xml.xpath("/instance/ssh_key/@href").
-          text.should == key_instance_url(@instance.instance_key)
-        xml.xpath("/instance/ssh_key_name").text.should == @instance.instance_key.name
-        #xml.xpath("/instance/history/entry").size.should > 0
-        #xml.xpath("/instance/history/entry/time").
-        #  text.should == @instance.events.first.event_time.strftime("%Y-%m-%d %H:%M:%S UTC")
-        #xml.xpath("/instance/history/entry/message").text.should == @instance.events.first.summary
+        check_instance_xml(xml.xpath("/instance"), @instance)
       end
 
       it "show nonexistent instance" do

--- a/src/spec/requests/api/instances_spec.rb
+++ b/src/spec/requests/api/instances_spec.rb
@@ -1,0 +1,106 @@
+#
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require 'spec_helper'
+
+describe "Instances" do
+  let(:headers) { {
+      'HTTP_ACCEPT' => 'application/xml',
+      'CONTENT_TYPE' => 'application/xml'
+    } }
+
+  context "API" do
+    before(:each) do
+      user = FactoryGirl.create(:admin_permission).user
+      login_as(user)
+      @instance = FactoryGirl.create(:mock_running_instance, :instance_config_xml => "<instance-config id='some-test-id'>some-test-data</instance-config>")
+      @instance.instance_key = FactoryGirl.create :mock_instance_key, :instance => @instance
+      @instance.instance_key.should_not be_nil
+    end
+
+    describe "#index" do
+
+      it "get index" do
+        get "/api/instances", nil, headers
+
+        response.should be_success
+        response.should have_content_type("application/xml")
+        response.body.should be_xml
+        xml = Nokogiri::XML(response.body)
+
+        xml.xpath("/instances/instance").size.should > 0
+        xml.xpath("/instances/instance[@id='#{@instance.id}']/@href").
+          text.should == api_instance_url(@instance.id)
+      end
+    end
+
+    describe "#show" do
+
+      it "show instance" do
+        get "/api/instances/#{@instance.id}", nil, headers
+        response.should be_success
+        response.should have_content_type("application/xml")
+        response.body.should be_xml
+        xml = Nokogiri::XML(response.body)
+        api_helper = Object.new.extend(ApiHelper)
+
+        xml.xpath("/instance/@id").text.should == @instance.id.to_s
+        xml.xpath("/instance/@href").text.should == api_instance_url(@instance)
+        xml.xpath("/instance/name").text.should == @instance.name
+        xml.xpath("/instance/external_key").text.should == @instance.external_key
+        #xml.xpath("/instance/state").text.should == @instance.state
+        xml.xpath("/instance/hardware_profile[@id='#{@instance.hardware_profile.id}']/@href").
+          text.should == api_hardware_profile_url(@instance.hardware_profile)
+        #xml.xpath("/instance/owner_id").text.should == @instance.owner_id.to_s
+        xml.xpath("/instance/pool[@id='#{@instance.pool.id}']/@href").
+          text.should == api_pool_url(@instance.pool)
+        xml.xpath("/instance/deployment[@id='#{@instance.deployment.id}']/@href").
+          text.should == api_deployment_url(@instance.deployment)
+        xml.xpath("/instance/provider_account[@id='#{@instance.provider_account.id}']/@href").
+          text.should == api_provider_account_url(@instance.provider_account)
+        xml.xpath("/instance/public_addresses").text.should == @instance.public_addresses
+        xml.xpath("/instance/private_addresses").text.should == @instance.private_addresses
+        xml.xpath("/instance/created_at").
+          text.should == api_helper.xmlschema_datetime(@instance.created_at)
+        xml.xpath("/instance/updated_at").
+          text.should == api_helper.xmlschema_datetime(@instance.updated_at)
+        xml.xpath("/instance/assembly_xml").inner_html.
+          should== @instance.assembly_xml.to_s
+        xml.xpath("/instance/instance_config_xml").inner_html.
+          should == @instance.instance_config_xml.to_s
+        #xml.xpath("/instance/image_uuid").text.should == @instance.image_uuid.to_s
+        #xml.xpath("/instance/image_build_uuid").text.should == @instance.image_build_uuid.to_s
+        #xml.xpath("/instance/provider_image_uuid").text.should == @instance.provider_image_uuid.to_s
+        #xml.xpath("/instance/provider_instance_id").text.should == @instance.provider_instance_id.to_s
+        xml.xpath("/instance/user_data").text.should == @instance.user_data.to_s
+        xml.xpath("/instance/ssh_key/@href").
+          text.should == key_instance_url(@instance.instance_key)
+        xml.xpath("/instance/ssh_key_name").text.should == @instance.instance_key.name
+        #xml.xpath("/instance/history/entry").size.should > 0
+        #xml.xpath("/instance/history/entry/time").
+        #  text.should == @instance.events.first.event_time.strftime("%Y-%m-%d %H:%M:%S UTC")
+        #xml.xpath("/instance/history/entry/message").text.should == @instance.events.first.summary
+      end
+
+      it "show nonexistent instance" do
+        get "/api/instances/-1", nil, headers
+        response.status.should == 404
+        response.should have_content_type("application/xml")
+        response.body.should be_xml
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Replaces #171 and #273.

Removed fields from show that are not ready to be displayed.

Updated date fields to new format.

Reference to deployment is now included in show.

Full resource representation is shown in top level collections.

Removed use of locals in show action.

Rebased to incorporate datetime changes in #274 to fix Ruby 1.8 build issues.
