### PR TITLE
add cost libs to rpm spec

### DIFF
--- a/aeolus-conductor.spec.in
+++ b/aeolus-conductor.spec.in
@@ -267,6 +267,7 @@ rb="app/models app/controllers app/controllers/api app/helpers app/mailers app/s
     spec/factories spec/helpers spec/models spec/services spec/util spec/controllers/api \
     spec/aeolus/event spec/aeolus/ext lib/aeolus lib/aeolus/event lib/aeolus/ext \
     lib/simple_form_extension \
+    lib/costengine \
     lib/provider_selection vendor/provider_selection \
     vendor/provider_selection/strategies/strict_order \
     vendor/provider_selection/strategies/penalty_for_failure"


### PR DESCRIPTION
this _should_ fix https://github.com/aeolusproject/aeolus-configure/issues/28

was not able to build the RPM yet :-(
