### PR TITLE
Edit src/config/compass.rb to match newest compass reqs

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -20,7 +20,7 @@ gem 'ruby-net-ldap', :require => 'net/ldap'
 gem 'aeolus-image', :git => "git://github.com/aeolusproject/aeolus-image-rubygem", :require => 'aeolus_image' #'>= 0.4.0',
 gem 'oauth'
 gem 'ldap_fluff'
-gem 'compass', '>= 0.11.5', '< 0.12'
+gem 'compass', '>= 0.12.2'
 gem 'compass-960-plugin', '>= 0.10.4', :require=> 'ninesixty'
 gem 'delayed_job', '~> 2.1.4'
 gem 'paranoia'

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -51,12 +51,12 @@ GEM
     childprocess (0.3.2)
       ffi (~> 1.0.6)
     chunky_png (1.2.5)
-    compass (0.11.7)
+    compass (0.12.2)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
       sass (~> 3.1)
     compass-960-plugin (0.10.4)
-      compass (>= 0.10.0)
+      compass (>= 0.12.2)
     crack (0.3.1)
     cucumber (1.2.0)
       builder (>= 2.1.2)
@@ -203,7 +203,7 @@ PLATFORMS
 DEPENDENCIES
   aeolus-image!
   capybara
-  compass (>= 0.11.5, < 0.12)
+  compass (>= 0.12.2)
   compass-960-plugin (>= 0.10.4)
   cucumber
   cucumber-rails

--- a/src/config/compass.rb
+++ b/src/config/compass.rb
@@ -2,13 +2,10 @@
 require 'ninesixty'
 
 # Set this to the root of your project when deployed:
-project_type = :rails
-project_path = Compass::AppIntegration::Rails.root
 http_path = "/"
 css_dir = "public/stylesheets/compiled"
 sass_dir = "app/stylesheets"
 images_dir = "public/images"
-environment = Compass::AppIntegration::Rails.env
 
 # You can select your preferred output style here (can be overridden via the command line):
 # output_style = :expanded or :nested or :compact or :compressed


### PR DESCRIPTION
This removes three lines from src/config/compass.rb because they
are incompatible with the newest upstream version of rubygem-compass.
