### PR TITLE
List all provider's hardware profiles

### DIFF
--- a/src/app/controllers/providers_controller.rb
+++ b/src/app/controllers/providers_controller.rb
@@ -323,12 +323,16 @@ class ProvidersController < ApplicationController
     @tabs = [{:name => t('connectivity'), :view => 'edit', :id => 'connectivity'},
              {:name => t('accounts'), :view => 'provider_accounts/list', :id => 'accounts', :count => @provider.provider_accounts.count},
              {:name => t('provider_realms.provider_realms'), :view => 'provider_realms/list', :id => 'realms', :count => @realms.count},
+             {:name => t('hardware_profiles.hardware_profiles'),
+              :view => 'hardware_profiles',
+              :id => 'hardware_profiles',
+              :count => @provider.hardware_profiles.count}
              #{:name => 'Roles & Permissions', :view => @view, :id => 'roles', :count => @provider.permissions.count},
     ]
     add_permissions_tab(@provider, "edit_")
     details_tab_name = params[:details_tab].blank? ? 'connectivity' : params[:details_tab]
     details_tab_name = 'connectivity' unless
-      ['connectivity', 'accounts', 'realms', 'permissions'].include?(details_tab_name)
+      ['connectivity', 'accounts', 'realms', 'hardware_profiles', 'permissions'].include?(details_tab_name)
     @details_tab = @tabs.find {|t| t[:id] == details_tab_name} || @tabs.first[:name].downcase
 
     if @details_tab[:id] == 'accounts'
@@ -337,6 +341,8 @@ class ProvidersController < ApplicationController
                         params[:provider_accounts_preset_filter],
                       :search_filter => params[:provider_accounts_search]).
         list_for_user(current_session, current_user, Privilege::VIEW)
+    elsif @details_tab[:id] == 'hardware_profiles'
+      @hardware_profiles = @provider.hardware_profiles
     end
     #@permissions = @provider.permissions if @details_tab[:id] == 'roles'
 

--- a/src/app/helpers/providers_helper.rb
+++ b/src/app/helpers/providers_helper.rb
@@ -24,4 +24,15 @@ module ProvidersHelper
     end
   end
 
+  def hardware_profiles_headers
+    [
+        t('hardware_profiles.provider_hwp_headers.hwp_name'),
+        t('hardware_profiles.provider_hwp_headers.architecture'),
+        t('hardware_profiles.provider_hwp_headers.memory'),
+        t('hardware_profiles.provider_hwp_headers.storage'),
+        t('hardware_profiles.provider_hwp_headers.virtual_cpu'),
+        t('hardware_profiles.provider_hwp_headers.minimal_cost')
+    ]
+  end
+
 end

--- a/src/app/views/providers/_hardware_profiles.html.haml
+++ b/src/app/views/providers/_hardware_profiles.html.haml
@@ -1,0 +1,27 @@
+%section.content-section
+  %header
+    %h2=t'hardware_profiles.hardware_profiles'
+  .content
+    - if @hardware_profiles.count > 0
+      %table.flat
+        %thead
+          %tr
+            - hardware_profiles_headers.each do |header|
+              %th=header
+          - @hardware_profiles.each do |hwp|
+            %tr
+              %td
+                = link_to hwp.name, hardware_profile_path(hwp)
+              %td
+                =hwp.architecture.to_s
+              %td
+                =hwp.memory.to_s
+              %td
+                =hwp.storage.to_s
+              %td
+                =hwp.cpu.to_s
+              %td
+                =hwp.default_cost_per_hour.nil? ? "N/A" : "%.3f" % hwp.default_cost_per_hour
+
+    - else
+      %h3= t('hardware_profiles.no_hwp')

--- a/src/config/locales/en.yml
+++ b/src/config/locales/en.yml
@@ -689,6 +689,7 @@ en:
     hardware: Hardware
     hardware_profile: Hardware Profile
     hardware_profiles: Hardware Profiles
+    no_hwp: No Hardware Profiles
     index:
       hardware_profile_name: Hardware Profile Name
       architecture: Architecture

--- a/src/features/provider.feature
+++ b/src/features/provider.feature
@@ -74,6 +74,13 @@ Feature: Manage Providers
     And I should see "Provider is disabled."
     And provider "mock1" should have all instances stopped
 
+  Scenario: Show hardware profiles for provider
+    Given there is a provider named "mock"
+    And this provider has 1 hardware profiles
+    When I go to the mock's edit provider page
+    And I follow "details_hardware_profiles"
+    Then I should see "hardware_profile"
+
 #  Scenario: Search for hardware profiles
 #    Given there are these providers:
 #    | name          | url                         |


### PR DESCRIPTION
Added tab 'Hardware Profiles' to provider's details. User is now abled
to see all hardware profiles of defined provider.

https://github.com/aeolusproject/conductor/issues/319
