### PR TITLE
BUGFIX: Don't force system ruby

### DIFF
--- a/src/dbomatic/dbomatic
+++ b/src/dbomatic/dbomatic
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 #
 # Copyright (C) 2010,2011 Red Hat, Inc.
 #


### PR DESCRIPTION
Dbomatic would only use system ruby before, which caused it to fail if you
were using a modern ruby via rvm or rbenv.
