### PR TITLE
Removed ruby1.8 checking from travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
 gemfile: src/Gemfile
 env: 


### PR DESCRIPTION
We won't support 1.8 version anymore.
