### PR TITLE
Fixed routes reloading

### DIFF
--- a/src/lib/viewstate.rb
+++ b/src/lib/viewstate.rb
@@ -66,7 +66,12 @@ module ActionController
                     :action => route[:action])
             end
           end
-          Conductor::Application.routes_reloader.paths.each { |path| load(path) }
+          #Conductor::Application.routes_reloader.paths.each { |path| load(path) }
+          # the above ^ doesn't work properly if engines routes are
+          # extended/changed in main app routes configuration - patchs are
+          # loaded in wrong order and extensions defined in main app are then
+          # overwritten
+          Conductor::Application.reload_routes!
           ActiveSupport.on_load(:action_controller) { route_set.finalize! }
         ensure
           route_set.disable_clear_and_finalize = false


### PR DESCRIPTION
Viewstate lib completely reloads all app routes. If engines are used
it's possible that routes are loaded in wrong order and then any
engine route extension defined in main app is overwritten.

How to reproduce:
Conductor adds additional 'edit_xml' action to base_images resource.
If you access e.g. /pools/index page (which calls the viewstate method
which reloads routes) and then if you access tim/base_images/new page,
you should get error:
Undefined method `edit_xml_base_images_path'
