### PR TITLE
Removes 'show me the page' test step

### DIFF
--- a/src/features/provider_account.feature
+++ b/src/features/provider_account.feature
@@ -81,7 +81,6 @@ Feature: Manage Provider Accounts
     And there is a provider account named "testaccount"
     And I am on the mockprovider's provider accounts page
     And I follow "testaccount"
-    And show me the page
     When I follow "Edit"
     And I fill in "provider_account[label]" with "testaccount_updated"
     And I fill in "provider_account[credentials_attributes][password]" with "mockpassword"


### PR DESCRIPTION
This was popping open elinks while running tests. I don't think
this should be in the repo, just added locally for debugging.
