### PR TITLE
Removes available_providers filter in ProvidersController

### DIFF
--- a/src/app/controllers/providers_controller.rb
+++ b/src/app/controllers/providers_controller.rb
@@ -302,8 +302,7 @@ class ProvidersController < ApplicationController
   end
 
   def load_providers_types
-    available_providers = ["Mock","Amazon EC2","RHEV-M","VMware vSphere","Rackspace","Openstack"]
-    provider_types = ProviderType.where(:name => available_providers).map do |type|
+    provider_types = ProviderType.all.map do |type|
       begin
         label = I18n.translate!("providers.form.x_deltacloud_provider.#{type.deltacloud_driver}")
       rescue


### PR DESCRIPTION
This:

a.) Served no constructive purpose. It was ostensibly to allow
 upstream to support everything, but product to only support
 fully-tested providers. Except the file was never changed.

b.) Does not belong in a controller.

c.) Breaks if you send a patch like my 'Openstack' -> 'OpenStack'
 one, unless I were to check for both strings, which would be
 a ridiculous mess.
