### PR TITLE
Fixes glance_url to use a string, not a text field

### DIFF
--- a/src/db/seeds.rb
+++ b/src/db/seeds.rb
@@ -218,6 +218,6 @@ if CredentialDefinition.all.empty?
 
   # For OpenStack provider type:
   if openstack = ProviderType.find_by_deltacloud_driver('openstack')
-    CredentialDefinition.create!(:name => 'glance_url', :label => 'glance_url', :input_type => 'text', :provider_type_id => openstack.id)
+    CredentialDefinition.create!(:name => 'glance_url', :label => 'glance_url', :input_type => 'string', :provider_type_id => openstack.id)
   end
 end


### PR DESCRIPTION
This updates db/seeds.rb only, without a migration. But since we're
updating before the release, there should be need for one.

It turns out that :type => 'text' gives you a textarea...

Closes https://github.com/aeolusproject/conductor/issues/335
