### PR TITLE
BaseImages#show shows provider accounts whether or not images are built

### DIFF
--- a/src/app/views/tim/base_images/_status.html.mustache
+++ b/src/app/views/tim/base_images/_status.html.mustache
@@ -1,4 +1,4 @@
-{{#images}}
+{{#targets}}
   <li class="clearfix">
     <dl>
       <dt>
@@ -15,10 +15,10 @@
               :method => :post) %>
           {{/build_url.present?}}
           {{#only_status.present?}}
-            {{status}}
-            {{#progress.present?}}
-              ({{progress}}%)
-            {{/progress.present?}}
+            {{timg_status}}
+            {{#timg_progress.present?}}
+              ({{timg_progress}}%)
+            {{/timg_progress.present?}}
           {{/only_status.present?}}
           <br>
           {{#failed_attempts.present?}}
@@ -41,7 +41,7 @@
             <th class="image_controls"></th>
           </tr></thead>
           <tbody>
-          {{#provider_images}}
+          {{#provider_accounts}}
             <tr>
               <td><strong> {{provider_account.name}} </strong></td>
               <td class="light">{{provider.name }} </td>
@@ -68,10 +68,10 @@
               {{/pimg_failed_attempts.present?}}
               </td>
             </tr>
-          {{/provider_images}}
+          {{/provider_accounts}}
           </tbody>
         </table>
       </dd>
     </dl>
   </li>
-{{/images}}
+{{/targets}}

--- a/src/app/views/tim/base_images/show.html.haml
+++ b/src/app/views/tim/base_images/show.html.haml
@@ -44,7 +44,7 @@
 
   .content
     %ul.image_builds
-      = render :partial => 'status', :mustache => {:images => @targets}
+      = render :partial => 'status', :mustache => {:targets => @targets}
 
 :javascript
   $(document).ready(function(){


### PR DESCRIPTION
This fixes a bug where the BaseImage detail page would only show the
available provider accounts if they had an image built.

Fixes https://github.com/aeolusproject/conductor/issues/306
