### PR TITLE
Remove iwhd from settings.yml

### DIFF
--- a/src/config/settings.yml
+++ b/src/config/settings.yml
@@ -8,11 +8,6 @@
   :enable_local: true
   # allows ldap-managed groups
   :enable_ldap: true
-:iwhd:
-  :url: http://localhost:9090
-  # :oauth:
-  #   :consumer_key: consumer_key_here
-  #   :consumer_secret: consumer_secret_here
 
 :imagefactory:
   :url: https://localhost:8075/imagefactory


### PR DESCRIPTION
No longer used now that conductor uses tim.
