### PR TITLE
Added snapshot support for image build&push

### DIFF
--- a/src/app/decorators/models/tim/target_image_decorator.rb
+++ b/src/app/decorators/models/tim/target_image_decorator.rb
@@ -27,6 +27,7 @@ Tim::TargetImage.class_eval do
 
   validates_presence_of :provider_type
 
+  before_create :set_snapshot_build
   before_validation :set_provider_type
   before_validation :set_target
 
@@ -74,6 +75,13 @@ Tim::TargetImage.class_eval do
   def status=(state)
     state = Tim::TargetImage::STATUS_COMPLETE if state == 'COMPLETED'
     write_attribute(:status, state)
+  end
+
+  def set_snapshot_build
+    if SETTINGS_CONFIG[:imagefactory][:snapshot_provider_types] &&
+      SETTINGS_CONFIG[:imagefactory][:snapshot_provider_types].include?(provider_type.deltacloud_driver)
+        self.build_method = 'SNAPSHOT'
+    end
   end
 
   private

--- a/src/app/models/provider.rb
+++ b/src/app/models/provider.rb
@@ -82,13 +82,6 @@ class Provider < ActiveRecord::Base
         load_json.present?
       when "VMware vSphere"
         load_json.present?
-      when "Amazon EC2"
-        if name.starts_with?("ec2-")
-          true
-        else
-          errors.add(:name, :start_with_ec2)
-          false
-        end
     end
   end
 
@@ -257,6 +250,8 @@ class Provider < ActiveRecord::Base
       else
         raise I18n.t("providers.errors.json_conf_not_found", :provider => self.name)
       end
+    elsif provider_type.deltacloud_driver == 'ec2'
+      {'name' => deltacloud_provider}
     else
       {}
     end

--- a/src/config/initializers/tim.rb
+++ b/src/config/initializers/tim.rb
@@ -17,8 +17,6 @@
 Tim.user_class = "User"
 Tim.provider_account_class = "ProviderAccount"
 Tim.provider_type_class = "ProviderType"
-# Image Factory URL
-Tim::ImageFactory::Base.site = "http://localhost:8075/imagefactory"
-# FIXME: We should be able to infer these from Routes
-Tim::ImageFactory::TargetImage.callback_url = "http://localhost:3000/tim/target_images/"
-Tim::ImageFactory::ProviderImage.callback_url = "http://localhost:3000/tim/provider_images/"
+Tim::ImageFactory::Base.site = SETTINGS_CONFIG[:imagefactory][:url]
+Tim::ImageFactory::TargetImage.callback_url = SETTINGS_CONFIG[:imagefactory][:callback_urls][:target_image]
+Tim::ImageFactory::ProviderImage.callback_url = SETTINGS_CONFIG[:imagefactory][:callback_urls][:provider_image]

--- a/src/config/settings.yml
+++ b/src/config/settings.yml
@@ -10,10 +10,18 @@
   :enable_ldap: true
 
 :imagefactory:
-  :url: https://localhost:8075/imagefactory
-  # :oauth:
-  #   :consumer_key: consumer_key_here
-  #   :consumer_secret: consumer_secret_here
+  :url: http://localhost:8075/imagefactory
+  :callback_urls:
+    :target_image: http://localhost:3000/tim/target_images/
+    :provider_image: http://localhost:3000/tim/provider_images/
+  # uncomment provider types for which you want to use snapshot build mode,
+  #:snapshot_provider_types:
+  #  - ec2
+  #  - mock
+  #  - openstack
+  #:oauth:
+  #  :consumer_key: consumer_key_here
+  #  :consumer_secret: consumer_secret_here
 
 :session:
   :timeout: 15 # minutes


### PR DESCRIPTION
Now user can set in config/settings.yml file for if she wants use
snasphot mode for providers for which imagefactory supports snapshots.
Currently these are: ec2, openstack, mock

This patch also removes the old annoying restriction when provider name
was used for finding realm on imagefactory side.

Fixes #276
