### PR TITLE
remove all foreign keys until rails is fixed

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -27,7 +27,6 @@ gem 'haml-rails'
 gem 'sass-rails'
 gem 'compass-rails'
 gem "alchemy", ">= 1.0.1"
-gem 'foreigner'
 
 platforms :ruby_18 do
   gem 'fastercsv'

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -100,8 +100,6 @@ GEM
       railties (>= 3.0.0)
     fastercsv (1.5.5)
     ffi (1.0.11)
-    foreigner (1.3.0)
-      activerecord (>= 3.0.0)
     fssm (0.2.9)
     gherkin (2.10.0)
       json (>= 1.4.6)
@@ -236,7 +234,6 @@ DEPENDENCIES
   deltacloud-client
   factory_girl_rails (~> 1.4.0)
   fastercsv
-  foreigner
   haml-rails
   json
   launchy

--- a/src/db/migrate/20130116112855_add_keys_catalog_entries.rb
+++ b/src/db/migrate/20130116112855_add_keys_catalog_entries.rb
@@ -1,6 +1,0 @@
-class AddKeysCatalogEntries < ActiveRecord::Migration
-  def change
-    add_foreign_key "catalog_entries", "catalogs", :name => "catalog_entries_catalog_id_fk"
-    add_foreign_key "catalog_entries", "deployables", :name => "catalog_entries_deployable_id_fk"
-  end
-end

--- a/src/db/migrate/20130116112856_add_keys_catalogs.rb
+++ b/src/db/migrate/20130116112856_add_keys_catalogs.rb
@@ -1,6 +1,0 @@
-class AddKeysCatalogs < ActiveRecord::Migration
-  def change
-    add_foreign_key "catalogs", "pool_families", :name => "catalogs_pool_family_id_fk"
-    add_foreign_key "catalogs", "pools", :name => "catalogs_pool_id_fk"
-  end
-end

--- a/src/db/migrate/20130116112858_add_keys_deployables.rb
+++ b/src/db/migrate/20130116112858_add_keys_deployables.rb
@@ -1,6 +1,0 @@
-class AddKeysDeployables < ActiveRecord::Migration
-  def change
-    add_foreign_key "deployables", "users", :name => "deployables_owner_id_fk", :column => "owner_id"
-    add_foreign_key "deployables", "pool_families", :name => "deployables_pool_family_id_fk"
-  end
-end

--- a/src/db/migrate/20130116112860_add_keys_deployments.rb
+++ b/src/db/migrate/20130116112860_add_keys_deployments.rb
@@ -1,9 +1,0 @@
-class AddKeysDeployments < ActiveRecord::Migration
-  def change
-    add_foreign_key "deployments", "frontend_realms", :name => "deployments_frontend_realm_id_fk"
-    add_foreign_key "deployments", "users", :name => "deployments_owner_id_fk", :column => "owner_id"
-    add_foreign_key "deployments", "pool_families", :name => "deployments_pool_family_id_fk"
-    add_foreign_key "deployments", "pools", :name => "deployments_pool_id_fk"
-    add_foreign_key "deployments", "provider_realms", :name => "deployments_provider_realm_id_fk"
-  end
-end

--- a/src/db/migrate/20130116112861_add_keys_hardware_profiles.rb
+++ b/src/db/migrate/20130116112861_add_keys_hardware_profiles.rb
@@ -1,9 +1,0 @@
-class AddKeysHardwareProfiles < ActiveRecord::Migration
-  def change
-    add_foreign_key "hardware_profiles", "hardware_profile_properties", :name => "hardware_profiles_architecture_id_fk", :column => "architecture_id"
-    add_foreign_key "hardware_profiles", "hardware_profile_properties", :name => "hardware_profiles_cpu_id_fk", :column => "cpu_id"
-    add_foreign_key "hardware_profiles", "hardware_profile_properties", :name => "hardware_profiles_memory_id_fk", :column => "memory_id"
-    add_foreign_key "hardware_profiles", "providers", :name => "hardware_profiles_provider_id_fk"
-    add_foreign_key "hardware_profiles", "hardware_profile_properties", :name => "hardware_profiles_storage_id_fk", :column => "storage_id"
-  end
-end

--- a/src/db/migrate/20130116112862_add_keys_pools.rb
+++ b/src/db/migrate/20130116112862_add_keys_pools.rb
@@ -1,6 +1,0 @@
-class AddKeysPools < ActiveRecord::Migration
-  def change
-    add_foreign_key "pools", "pool_families", :name => "pools_pool_family_id_fk"
-    add_foreign_key "pools", "quotas", :name => "pools_quota_id_fk"
-  end
-end

--- a/src/db/migrate/20130116112863_add_keys_pool_families.rb
+++ b/src/db/migrate/20130116112863_add_keys_pool_families.rb
@@ -1,5 +1,0 @@
-class AddKeysPoolFamilies < ActiveRecord::Migration
-  def change
-    add_foreign_key "pool_families", "quotas", :name => "pool_families_quota_id_fk"
-  end
-end

--- a/src/db/migrate/20130116112864_add_keys_pf_pa.rb
+++ b/src/db/migrate/20130116112864_add_keys_pf_pa.rb
@@ -1,6 +1,0 @@
-class AddKeysPfPa < ActiveRecord::Migration
-  def change
-    add_foreign_key "pool_families_provider_accounts", "pool_families", :name => "pool_families_provider_accounts_pool_family_id_fk"
-    add_foreign_key "pool_families_provider_accounts", "provider_accounts", :name => "pool_families_provider_accounts_provider_account_id_fk"
-  end
-end


### PR DESCRIPTION
remove all foreign keys from database until Rails is released with this fixed:  
https://github.com/rails/rails/pull/8548                                        

keeping the FKs causes dev-tools to fail as described in the Rails issue
