### PR TITLE
BZ 870479 - fixed checking of "stopped after creation" state

### DIFF
--- a/src/app/models/instance.rb
+++ b/src/app/models/instance.rb
@@ -522,7 +522,7 @@ class Instance < ActiveRecord::Base
       # also make sure that the 'create' task was created after
       # last deployment launch request - instance can be stopped
       # since previous rollback+retry request
-      last_task.created_at.to_i > last_launch_time.to_i &&
+      last_task.created_at.to_f > last_launch_time.to_f &&
       provider_account &&
       provider_account.provider.provider_type.goes_to_stop_after_creation?
   end


### PR DESCRIPTION
For rhevm/vsphere an instance goes to 'stopped' state after creation so
conductor has to send explicit start request. To distinguish "stopped after
creation" state and common "stopped" state conductor checks if last
instance launch request was sent after last deployment launch request
(there can be multiple launch requests for deployment/instance because of
rolblack+retry process).

In some cases it was possible that instance launch request was picked up by
delayed_job in same second when the deployment was created, so checking create
times by seconds was not precise enough.
