### PR TITLE
Remove image caching from Deployable model

### DIFF
--- a/src/app/controllers/pools_controller.rb
+++ b/src/app/controllers/pools_controller.rb
@@ -137,7 +137,6 @@ class PoolsController < ApplicationController
           #  this patch is after string freeze so I'm confined to using them. --mawagner
           @header = [{:name => _('Catalog')}, {:name => _('Deployable')},
                      {:name => _('Image')}, {:name => _('Provider\'s Image ID')}]
-          @catalog_images = @pool.catalog_images_collection(@catalogs)
         when 'deployments'
           @view = filter_view? ? 'deployments/list' : 'deployments/pretty_view'
       end

--- a/src/app/models/deployable.rb
+++ b/src/app/models/deployable.rb
@@ -116,26 +116,11 @@ class Deployable < ActiveRecord::Base
   end
 
   def fetch_unique_images
-    uuids = fetch_image_uuids || []
-    uniq_uuids = uuids.uniq
-    result_hash = {}
-    uniq_uuids.each do |uuid|
-      result_hash[uuid] = { :image => Tim::BaseImage.find_by_uuid(uuid), :count => uuids.count(uuid)}
-    end
-    result_hash
-  end
+    deployable_xml = fetch_deployable
+    return [] if deployable_xml.nil?
 
-
-  def fetch_image_uuids
-    deployable = fetch_deployable
-    deployable.image_uuids unless deployable.nil?
-  end
-
-  def hw_profile_for_image(image_id)
-    fetch_deployable.assemblies.each do |as|
-      if as.image_id == image_id
-       return HardwareProfile.find_by_name(as.hwp)
-      end
+    deployable_xml.image_uuids.uniq.map do |image_uuid|
+      Tim::BaseImage.find_by_uuid(image_uuid)
     end
   end
 
@@ -316,4 +301,5 @@ class Deployable < ActiveRecord::Base
       scoped
     end
   end
+
 end

--- a/src/app/models/pool.rb
+++ b/src/app/models/pool.rb
@@ -170,28 +170,6 @@ class Pool < ActiveRecord::Base
     subtree
   end
 
-  def catalog_images_collection(catalog_list)
-    catalog_images = []
-    catalog_list.each do |catalog|
-      catalog.deployables.each do |deployable|
-        deployable.fetch_unique_images.each do |key,value|
-          if value[:image].present?
-            row = {:catalog => catalog.name ,:deployable => deployable.name,
-                   :image => "#{value[:image].name} #{value[:image].uuid}",
-                   :provider_images =>[] }
-
-            value[:image].provider_images.each do |provider_image|
-              row[:provider_images] << _('pushed to %s, provider id: %s') % [provider_image.external_image_id, provider_image.provider_account.provider.name]
-
-            end
-            value[:count].times { catalog_images << row }
-          end
-        end
-      end
-    end
-    catalog_images
-  end
-
   private
 
   def self.apply_search_filter(search)

--- a/src/app/views/pools/_images.html.haml
+++ b/src/app/views/pools/_images.html.haml
@@ -5,12 +5,12 @@
         =image_tag 'flash_error_icon.png', :alt => 'Errors'
         =flash[:error]
 -else
-=filter_table(@header,@catalog_images) do |catalog_image|
-  %tr{:class => cycle('nostripe','stripe')}
-    %td=catalog_image[:catalog]
-    %td=catalog_image[:deployable]
-    %td=catalog_image[:image]
-    %td
-      %ul
-        - catalog_image[:provider_images].each do |img|
-          %li= img
+  =filter_table(@header, @catalogs)  do |catalog|
+    - catalog.deployables.each do |deployable|
+      - deployable.fetch_unique_images.each do |image|
+        %tr{:class => cycle('nostripe','stripe')}
+          %td= catalog.name
+          %td= deployable.name
+          %td= "#{image.name} (#{image.uuid})"
+          - image.provider_images.each do |provider_image|
+            %td= _('pushed to %s, provider id: %s') % [provider_image.external_image_id, provider_image.provider_account.provider.name]


### PR DESCRIPTION
The caching was added because the image details were queried from ImageWarehouse over HTTP. With TIM, it's all stored in DB, so no need for this kind of caching.
