### PR TITLE
Initial Heat integration

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -33,6 +33,7 @@ gem 'sass-rails'
 gem 'compass-rails'
 gem "alchemy", ">= 1.0.1"
 gem 'gettext_i18n_rails'
+gem 'cbf', ">= 0.0.3"
 
 platforms :ruby_18 do
   gem 'fastercsv'

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -47,7 +47,7 @@ GIT
       thor (>= 0.14.6, < 2.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     addressable (2.2.8)
     alchemy (1.0.2)
@@ -61,6 +61,8 @@ GEM
       rack-test (>= 0.5.4)
       selenium-webdriver (~> 2.0)
       xpath (~> 0.1.4)
+    cbf (0.0.3)
+      nokogiri (~> 1.5.0)
     childprocess (0.3.2)
       ffi (~> 1.0.6)
     chunky_png (1.2.7)
@@ -237,6 +239,7 @@ PLATFORMS
 DEPENDENCIES
   alchemy (>= 1.0.1)
   capybara
+  cbf (>= 0.0.3)
   compass-rails
   cucumber
   cucumber-rails

--- a/src/app/models/deployment.rb
+++ b/src/app/models/deployment.rb
@@ -82,7 +82,6 @@ class Deployment < ActiveRecord::Base
   before_create :inject_launch_parameters
   before_create :generate_uuid
   before_create :set_pool_family
-  before_create :set_new_state
   after_save :log_state_change
   after_save :handle_completed_rollback
 
@@ -136,6 +135,22 @@ class Deployment < ActiveRecord::Base
   def pool_must_be_enabled
     errors.add(:pool, _('must be enabled')) unless pool and pool.enabled?
     errors.add(:pool, _('has all associated Providers disabled')) if pool and pool.pool_family.all_providers_disabled?
+  end
+
+  def state
+    return STATE_NEW unless heat_data
+    heat_state_map = {
+      "CREATE_COMPLETE" => STATE_RUNNING,
+      "CREATE_FAILED" => STATE_FAILED,
+      "CREATE_IN_PROGRESS" => STATE_PENDING,
+    }
+    heat_state_map[heat_data['stack_status']]
+  rescue Heat::NotFoundError
+    STATE_FAILED
+  end
+
+  def state=(new_state)
+    raise "Cannot set the state from here. Talk to Heat instead."
   end
 
   def perm_ancestors
@@ -231,8 +246,6 @@ class Deployment < ActiveRecord::Base
 
   def launch!(user)
     self.reload unless self.new_record?
-    self.state = STATE_PENDING
-    save!
 
     all_inst_match, account, errs = pick_provider_selection_match
 
@@ -256,49 +269,37 @@ class Deployment < ActiveRecord::Base
     # InstanceMatch model, delayed job tries to load this object from DB
     all_inst_match.map!{|m| m.attributes}
 
-    if deployable_xml.requires_config_server?
-      config_server_id = account.config_server.id
-    else
-      config_server_id = nil
-    end
-
-    delay.send_launch_requests(all_inst_match,
+    # TODO(shadower): uncomment this.
+    # I disabled the delayed job version to make debugging easier for now
+    # delay.send_launch_requests(...)
+    send_launch_requests(all_inst_match,
                                instances.map{|i| i.id},
-                               config_server_id, user.id)
+                               user.id)
   end
 
-  def send_launch_requests(all_inst_match, instance_ids, config_server_id, user_id)
+
+  def send_launch_requests(all_inst_match, instance_ids, user_id)
     user = User.find(user_id)
     instances = instance_ids.map{|instance_id| Instance.find(instance_id)}
 
-    if config_server_id.nil?
-      config_server = nil
-      instance_configs = {}
-    else
-      config_server = ConfigServer.find(config_server_id)
-
-      # the instance configurations need to be generated from the entire set of
-      # instances (and not each individual instance) in order to do parameter
-      # dependency resolution across the set
-      instance_configs = ConfigServerUtil.instance_configs(self,instances,config_server)
-    end
-
+    instance_matches = []
     instances.each do |instance|
       instance.reset_attrs unless instance.state == Instance::STATE_NEW
       instance.instance_matches << InstanceMatch.new(
         all_inst_match.find{|m| m['instance_id'] == instance.id})
-      begin
-        instance.launch!(instance.instance_matches.last,
-                         user,
-                         config_server,
-                         instance_configs[instance.uuid])
-      rescue
-        # be default launching of instances is terminated if an error occurs,
-        # user can set "partial_launch" attribute - launch request is then
-        # sent for all deployment's instances
-        break unless partial_launch
-      end
+
+      instance_matches << instance.instance_matches.last
     end
+
+    instance_matches.each do |match|
+      instance = match.instance
+      instance.provider_account = match.provider_account
+      instance.save!
+      instance.create_auth_key unless instance.instance_key
+    end
+
+    heat_template = CBF::convert(deployable_xml.to_s, :aeolus, {:require_instance_keys => true}).to(:heat)
+    Heat.create_stack(heat_connection(instance_matches), name, heat_template, instance_matches)
     true
   end
 
@@ -514,7 +515,38 @@ class Deployment < ActiveRecord::Base
     {:title => "deployments.preset_filters.rollback_failed", :id => "rollback_failed", :query => where("deployments.state" => "rollback_failed")}
   ]
 
+  def heat_data(details=nil)
+    result = Heat::get_stack(heat_connection, name)
+    stack_url = result['links'].find {|link| link['rel'] == 'self'}['href']
+    if details == :all
+      result.merge! Heat::list_resources(heat_connection, stack_url)
+    end
+    result
+  rescue Heat::NoConnectionError
+    nil
+  end
+
   private
+
+  def heat_connection(instance_matches=nil)
+    # We assume that all the instances are being launched on the same provider
+    # with the same credentials
+    if instance_matches.blank?
+      instance = instances.first
+    else
+      instance = instance_matches.first.instance
+    end
+    return nil unless instance && instance.provider_account
+    provider_url = instance.provider_account.provider.url
+    credentials = instance.provider_account.credentials_hash
+    {
+      :heat_api => SETTINGS_CONFIG[:heat][:url],
+      :tenant_id => SETTINGS_CONFIG[:heat][:tennant_id],
+      :username => credentials['username'],
+      :password => credentials['password'],
+      :deltacloud_url => provider_url,
+    }
+  end
 
   def self.apply_search_filter(search)
     # TODO: after upgrading to 3.1 the SQL join statement can be done in Rails way by adding a has_many association to providers through provider_accounts

--- a/src/app/models/instance.rb
+++ b/src/app/models/instance.rb
@@ -68,8 +68,6 @@ class Instance < ActiveRecord::Base
   end
   include PermissionedObject
 
-  before_destroy :destroyable?
-
   belongs_to :pool
   belongs_to :pool_family
   belongs_to :provider_account
@@ -344,10 +342,6 @@ class Instance < ActiveRecord::Base
     false
   end
 
-  def destroyable?
-    (state == STATE_CREATE_FAILED) || (state == STATE_STOPPED && ! restartable?) || (state == STATE_VANISHED)
-  end
-
   def failed?
     FAILED_STATES.include?(state)
   end
@@ -414,15 +408,6 @@ class Instance < ActiveRecord::Base
   def includes_instance_match?(match)
     instance_matches.any?{|m| m.equals?(match)}
   end
-
-  def launch!(match, user, config_server, config)
-    # create a taskomatic task
-    task = InstanceTask.create!({:user        => user,
-                                 :task_target => self,
-                                 :action      => InstanceTask::ACTION_CREATE})
-    Taskomatic.create_instance!(task, match, config_server, config)
-  end
-
 
   def self.csv_export(instances)
     csvm = get_csv_class

--- a/src/app/models/provider_account.rb
+++ b/src/app/models/provider_account.rb
@@ -378,8 +378,6 @@ class ProviderAccount < ActiveRecord::Base
       errors << _('%s: Hardware Profile match not found') % name
     elsif !(account_image = instance.provider_image_for_account(self))
       errors << _('%s: Image is not pushed to this Provider Account') % name
-    elsif instance.requires_config_server? and config_server.nil?
-      errors << _('%s: no Config Server available for Provider Account') % name
     else
       if not instance.frontend_realm.nil?
         brealms = instance.frontend_realm.realm_backend_targets.select do |brealm_target|

--- a/src/app/util/heat.rb
+++ b/src/app/util/heat.rb
@@ -1,0 +1,128 @@
+class Heat
+
+  class NotFoundError < StandardError
+  end
+
+  class NoConnectionError < StandardError
+  end
+
+  class << self
+
+    def heat_request(connection, method, url, params, body)
+      raise NoConnectionError unless connection
+
+      method = method.to_s.downcase
+      raise 'invalid method' unless ['get','put', 'post', 'delete'].include? method
+      method = method.to_sym
+
+      key = [method, url, params]
+      if Rails.cache.exist? key, :namespace => 'heat'
+          response, request, result = Rails.cache.read(key, :namespace => 'heat')
+          yield response, request, result
+          return
+      end
+
+      request_hash = {
+        :method => method,
+        :url => url,
+        :headers => {
+          :content_type => :json,
+          :accept => :json,
+          :'x-auth-user' => connection[:username],
+          :'x-auth-key' => connection[:password],
+          :'x-auth-url' => connection[:deltacloud_url],
+          :'x-roles' => '',
+          :params => params,
+        },
+      }
+      request_hash[:payload] = body.to_json if body.present?
+
+      RestClient::Request::execute(request_hash) do |response, request, result, &block|
+        if [:head, :get].include?(method) and [301, 302, 307].include?(response.code)
+          response.follow_redirection(request, result, &block)
+        else
+          if method == :get
+            Rails.cache.write(key, [response, request, result],
+              :namespace => 'heat',
+              :expires_in => 10.seconds,
+              :race_condition_ttl => 1.second)
+          end
+          yield response, request, result
+        end
+      end
+    end
+
+    def heat_url(connection, path='')
+      return nil unless connection
+
+      api_url = URI.join(connection[:heat_api], "/v1/#{connection[:tenant_id]}")
+      File.join(api_url.to_s, path)
+    end
+
+    def create_stack(connection, name, template, instance_matches)
+      parameters = {}
+      instance_matches.each do |match|
+        instance_name = match.instance.assembly_xml.name
+        parameters["#{instance_name}_image"] = match.provider_image
+        parameters["#{instance_name}_hardware_profile"] = match.hardware_profile.name
+        parameters["#{instance_name}_key_name"] = match.instance.instance_key.name
+      end
+
+      body = {
+        'stack_name' => name,
+        'template' => template,
+        'parameters' => parameters,
+      }
+
+      heat_request(connection, :post, heat_url(connection, '/stacks'), nil, body) do
+        |response, request, result, &block|
+        response.return!(request, result, &block) unless response.code == 201
+      end
+
+    end
+
+    def list_stacks(connection)
+      heat_request(connection, :get, heat_url(connection, '/stacks'), nil, nil) do
+        |response, request, result, &block|
+        case response.code
+        when 200
+          return JSON::load(response)['stacks']
+        when 404
+          raise NotFoundError
+        else
+          response.return!(request, result, &block)
+        end
+      end
+    end
+
+    def get_stack(connection, stack_name)
+      heat_request(connection, :get, heat_url(connection, "/stacks/#{stack_name}"), nil, nil) do
+        |response, request, result, &block|
+        case response.code
+        when 200
+          return JSON::load(response)["stack"]
+        when 404
+          raise NotFoundError
+        else
+          response.return!(request, result, &block)
+        end
+      end
+    end
+
+    def list_resources(connection, stack_url)
+      resources_url = URI.join(stack_url + '/', 'resources').to_s
+      heat_request(connection, :get, resources_url, nil, nil) do
+        |response, request, result, &block|
+        case response.code
+        when 200
+          return JSON::load(response)
+        when 404
+          raise NotFoundError
+        else
+          response.return!(request, result, &block)
+        end
+      end
+    end
+
+  end
+end

--- a/src/config/settings.yml
+++ b/src/config/settings.yml
@@ -23,6 +23,10 @@
   #  :consumer_key: consumer_key_here
   #  :consumer_secret: consumer_secret_here
 
+:heat:
+  :url: http://localhost:8004/
+  :tennant_id: deltacloud
+
 :session:
   :timeout: 15 # minutes
 


### PR DESCRIPTION
This is the first step towards full Heat integration. This routes deployment launching and querying for status to Heat. Launch-time parameters should just work, ditto for deleting the instances.

This is mostly to give you guys a direction where I think this should go and to get comments and feedback. I don't think it's wise to merge it just yet -- we need to test it more, clean up the code, find the subtle things this breaks, etc.

There are also a few issues that need fixing:
- Heat's API supports atomic launch (i.e. rollback) but as far as I know, it's not been implemented yet
- There's a bug in Heat that means the actual instance status isn't reported back correctly. If you launch a deployment and stop the instances out of band, Heat will show them as running.
- Heat generates its own wealth of events that we should show in Conductor. They're currently being ignored.

There's also an issue of performance. The way it's implemented now, every time you ask a deployment or an instance for a status, they request the Heat API for an up-to-date value.

This happens a lot of times and it crawls the entire UI into a halt.

I tried caching the value for the lifetime of the object as a simple workaround for rendering, but apparently, we (or Rails) are instantiating the same Deployment and Instance model objects over and over again when rendering the view so this didn't help much.

The same issue is exists with a database backend as well, but Rails transparently caches the DB queries for each controller action.

As a band-aid, I hooked `Heat::heat_request` to the Rails cache which deals with the issue.

Eventually though, we need to think of a better way to solve it -- either by reducing the number of instances we create or by introducing a proper HTTP caching layer.

Heat's API currently doesn't have any querying capabilities, so to list a few deployments, you have to send a separate request for each and then another request per instance to get instance properties as well. We could work with the Heat community to extend the API in a way that would mean issuing fewer requests.

Before we commit to any optimizations though, it's better to have the raw thing so that we can measure where the bottlenecks actually lie. The advantage of using the built-in Rails caching API here is that you can disable it in the app config without changing anything in the code.
## Try it out

You need Heat running with Deltacloud as a backend. I'll write a proper guide tomorrow (I need to package a couple of Python libraries to make things easier).

If you're adventurous, you can go ahead and follow the respective guides:

You can get Heat from here: https://github.com/openstack/heat

No need to set up OpenStack, we're not using it. Though Heat does use a few OpenStack libraries for dependencies.

Next, install `deltacloud_heat` which is a Deltacloud backend for Heat. It in turn uses the Deltacloud Python client.

https://github.com/tomassedovic/deltacloud_heat

https://github.com/tomassedovic/deltacloud

There were some bugs fixed in the Deltacloud API that we require, you need at least version 1.1.0. We also need the latest Python client which I didn't get  to submitting upstream yet. In short, use the server and the client from my fork above.

To configure Heat to use Deltacloud, open the `/etc/heat/heat-engine.conf` file and add the following line at the end:

```
cloud_backend=deltacloud_heat.clients
```

Then open `/etc/heat/heat-api.conf` and uncomment the last two lines:

```
[paste_deploy]
flavor = custombackend
```

Start the Heat engine and api services (if you're going to use the Audrey features, start cloudwatch and cfn-api as well).

That should be it.
