### PR TITLE
use unreleased dc-client version to prevent problems with openstack

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -1,10 +1,11 @@
-source :rubygems
+source 'https://rubygems.org'
 
 # This is in between 3.2.11 and 3.2.12, and should be removed once 3.2.12 is released.
 # See - https://github.com/rails/rails/pull/8895#issuecomment-12156101
 gem 'rails', :git => "git://github.com/rails/rails", :ref => '63970dc7db273551f977483109dde936c8a7554f'
 
-gem 'deltacloud-client', :require => 'deltacloud'
+gem 'deltacloud-client', :require => 'deltacloud', :git => "git://github.com/apache/deltacloud", :ref => '6e6424af4a0a038f7b236d17d760dbaa1ed28686'
+
 gem 'mustache'
 gem 'will_paginate', '>= 3.0.pre1'
 gem 'nokogiri'

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: git://github.com/apache/deltacloud
+  revision: 6e6424af4a0a038f7b236d17d760dbaa1ed28686
+  ref: 6e6424af4a0a038f7b236d17d760dbaa1ed28686
+  specs:
+    deltacloud-client (1.1.1)
+      nokogiri (>= 1.4.3)
+      rest-client (>= 1.6.1)
+
+GIT
   remote: git://github.com/rails/rails
   revision: 63970dc7db273551f977483109dde936c8a7554f
   ref: 63970dc7db273551f977483109dde936c8a7554f
@@ -47,7 +56,7 @@ GIT
       thor (>= 0.14.6, < 2.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     addressable (2.2.8)
     alchemy (1.0.2)
@@ -85,9 +94,6 @@ GEM
     delayed_job (2.1.4)
       activesupport (~> 3.0)
       daemons
-    deltacloud-client (1.0.4)
-      nokogiri (>= 1.4.3)
-      rest-client (>= 1.6.1)
     diff-lcs (1.1.3)
     erubis (2.7.0)
     eventmachine (1.0.0)
@@ -231,7 +237,7 @@ DEPENDENCIES
   cucumber-rails
   database_cleaner
   delayed_job (~> 2.1.4)
-  deltacloud-client
+  deltacloud-client!
   factory_girl_rails (~> 1.4.0)
   fastercsv
   haml-rails


### PR DESCRIPTION
need to get an unreleased version of dc-client to get openstack working
