### PR TITLE
Enable slow query warnings in development environment

### DIFF
--- a/src/config/environments/development.rb
+++ b/src/config/environments/development.rb
@@ -18,7 +18,7 @@ Conductor::Application.configure do
   # Settings specified here will take precedence over those in config/environment.rb
 
   # In the development environment your application's code is reloaded on
-  # every request.  This slows down response time but is perfect for development
+  # every request. This slows down response time but is perfect for development
   # since you don't have to restart the webserver when you make code changes.
   config.cache_classes = false
 
@@ -53,6 +53,10 @@ Conductor::Application.configure do
 
   # Otherwise we eat these connections even outside of tests:
   WebMock.allow_net_connect! if defined?(WebMock)
+
+  # Log the query plan for queries taking more than this (works
+  # with SQLite, MySQL, and PostgreSQL)
+  config.active_record.auto_explain_threshold_in_seconds = 0.5
 
   # Do not compress assets
   config.assets.compress = false


### PR DESCRIPTION
This feature was introduced in Rails 3.2 and is enabled by default in new projects.
