### PR TITLE
Remove Ruby 1.8 from Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
 gemfile: src/Gemfile


### PR DESCRIPTION
Ruby 1.8 EOL is on June 2013. Let's not consume spare Travis cycles if we don't need to.
